### PR TITLE
Store newsletter data in basket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ The `--recursive` is important!
 Make a virtualenv
 -----------------
 
-Using virualenvwrapper::
+Using virtualenvwrapper::
 
     mkvirtualenv --python=python2.6 basket
 
@@ -105,7 +105,22 @@ Advanced emailing
 If you require special logic for sending your email, you can subclass
 ``emailer.Emailer`` in a module of your choice (recommended:
 inside ``libs/custom_emailers``). Set the
-``emailer_class`` field accordingly for the applicable email (see emails.home.Reminder for an example). 
+``emailer_class`` field accordingly for the applicable email (see emails.home.Reminder for an example).
 
-When you run the ``sendmail`` command above, your Emailer will be used instead 
+When you run the ``sendmail`` command above, your Emailer will be used instead
 of the default one.
+
+Testing
+=======
+
+::
+
+    ./manage.py test [appnames]
+
+For example::
+
+    ./manage.py test emailer news
+
+You can also run particular test classes::
+
+    ./manage.py test news.TestNewsletters

--- a/apps/news/README
+++ b/apps/news/README
@@ -1,7 +1,10 @@
 
 This "news" app provides a service for managing Mozilla newsletters.
 
-Available newsletters:
+`fixtures/newsletters.json` is a fixture that can be used to load some initial
+data, but is probably out of date by the time you read this.
+
+Available newsletters (might be out of date):
 
 * mozilla-and-you
 * firefox-tips

--- a/apps/news/admin.py
+++ b/apps/news/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Subscriber
+from .models import Newsletter, Subscriber
 
 
 class SubscriberAdmin(admin.ModelAdmin):
@@ -10,3 +10,11 @@ class SubscriberAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Subscriber, SubscriberAdmin)
+
+
+class NewsletterAdmin(admin.ModelAdmin):
+    list_display = ['title', 'show', 'active', 'description', 'welcome',
+                    'languages']
+
+
+admin.site.register(Newsletter, NewsletterAdmin)

--- a/apps/news/fixtures/newsletters.json
+++ b/apps/news/fixtures/newsletters.json
@@ -1,0 +1,268 @@
+[
+  {
+    "pk": 1, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "MOZILLA_AND_YOU", 
+      "description": "A monthly newsletter packed with tips to improve your browsing experience.", 
+      "show": true, 
+      "welcome": "", 
+      "languages": "de,en-US,es,fr,id,pt-BR,ru", 
+      "active": true, 
+      "title": "Firefox & You", 
+      "slug": "mozilla-and-you"
+    }
+  }, 
+  {
+    "pk": 2, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "ABOUT_MOBILE", 
+      "description": "Get the power of Firefox in the palm of your hand.", 
+      "show": true, 
+      "welcome": "", 
+      "languages": "de,en-US,es,fr,id,pt-BR,ru", 
+      "active": true, 
+      "title": "Firefox for Android", 
+      "slug": "mobile"
+    }
+  }, 
+  {
+    "pk": 3, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "FIREFOX_TIPS", 
+      "description": "Get a weekly tip on how to super-charge your Firefox experience.", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "Firefox Weekly Tips", 
+      "slug": "firefox-tips"
+    }
+  }, 
+  {
+    "pk": 5, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "AURORA", 
+      "description": "Aurora", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "Aurora", 
+      "slug": "aurora"
+    }
+  }, 
+  {
+    "pk": 6, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "ABOUT_MOZILLA", 
+      "description": "News from the Mozilla Project", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": true, 
+      "title": "About Mozilla", 
+      "slug": "about-mozilla"
+    }
+  }, 
+  {
+    "pk": 19, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "FLICKS", 
+      "description": "", 
+      "show": true, 
+      "welcome": "Firefox_Flicks_Welcome", 
+      "languages": "en-US", 
+      "active": true, 
+      "title": "Firefox Flicks", 
+      "slug": "firefox-flicks"
+    }
+  }, 
+  {
+    "pk": 18, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "AFFILIATES", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "Firefox Affiliates", 
+      "slug": "affiliates"
+    }
+  }, 
+  {
+    "pk": 17, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "APP_DEV", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "Firefox Apps & Hacks", 
+      "slug": "app-dev"
+    }
+  }, 
+  {
+    "pk": 16, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "MOZILLA_PHONE", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": true, 
+      "title": "Mozillians", 
+      "slug": "mozilla-phone"
+    }
+  }, 
+  {
+    "pk": 15, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "JOIN_MOZILLA", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "Join Mozilla", 
+      "slug": "join-mozilla"
+    }
+  }, 
+  {
+    "pk": 14, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "ADD_ONS", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "Addon Development", 
+      "slug": "addon-dev"
+    }
+  }, 
+  {
+    "pk": 7, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "DRUMBEAT_NEWS_GROUP", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "Drumbeat Newsgroup", 
+      "slug": "drumbeat"
+    }
+  }, 
+  {
+    "pk": 8, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "ABOUT_ADDONS", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "About Addons", 
+      "slug": "addons"
+    }
+  }, 
+  {
+    "pk": 9, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "ABOUT_LABS", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "About Labs", 
+      "slug": "labs"
+    }
+  }, 
+  {
+    "pk": 10, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "n/a", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "QA News", 
+      "slug": "qa-news"
+    }
+  }, 
+  {
+    "pk": 12, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "ABOUT_STANDARDS", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "About Standards", 
+      "slug": "about-standards"
+    }
+  }, 
+  {
+    "pk": 13, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "MOBILE_ADDON_DEV", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": false, 
+      "title": "Mobile Addon Development", 
+      "slug": "mobile-addon-dev"
+    }
+  }, 
+  {
+    "pk": 11, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "STUDENT_REPS", 
+      "description": "", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": true, 
+      "title": "Student Reps", 
+      "slug": "student-reps"
+    }
+  }, 
+  {
+    "pk": 4, 
+    "model": "news.newsletter", 
+    "fields": {
+      "vendor_id": "FIREFOX_BETA_NEWS", 
+      "description": "Read about the latest features for Firefox desktop and mobile before the final release.", 
+      "show": false, 
+      "welcome": "", 
+      "languages": "en-US", 
+      "active": true, 
+      "title": "Beta News", 
+      "slug": "beta"
+    }
+  }
+]

--- a/apps/news/models.py
+++ b/apps/news/models.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+from django.conf import settings
 from django.db import models
 
 
@@ -25,3 +26,64 @@ class Subscriber(models.Model):
     token = models.CharField(max_length=1024, default=lambda: str(uuid4()))
 
     objects = SubscriberManager()
+
+
+class Newsletter(models.Model):
+    slug = models.SlugField(unique=True)
+    title = models.CharField(
+        max_length=128,
+        help_text="Public name of newsletter in English",
+    )
+    description = models.CharField(
+        max_length=256,
+        help_text="One-line description of newsletter in English",
+        blank=True,
+    )
+    show = models.BooleanField(
+        default=False,
+        help_text="Whether to show this newsletter in lists of newsletters, "
+                  "even to non-subscribers",
+    )
+    active = models.BooleanField(
+        default=True,
+        help_text="Whether this newsletter is active. Inactive newsletters "
+                  "are only shown to those who are already subscribed, and "
+                  "might have other differences in behavior.",
+    )
+    # Note: use .welcome_id property to get this field or the default
+    welcome = models.CharField(
+        max_length=64,
+        help_text="The ID of the welcome message sent for this newsletter. "
+                  "This is the HTML version of the message; append _T to this "
+                  "ID to get the ID of the text-only version.  If blank, "
+                  "default is %s." % settings.DEFAULT_WELCOME_MESSAGE_ID,
+        blank=True,
+    )
+    vendor_id = models.CharField(
+        max_length=128,
+        help_text="The backend vendor's identifier for this newsletter",
+    )
+    languages = models.CharField(
+        max_length=200,
+        help_text="Comma-separated list of the language codes that this "
+                  "newsletter supports",
+    )
+
+    def __unicode__(self):
+        return self.title
+
+    def save(self, *args, **kwargs):
+        # Strip whitespace from langs before save
+        self.languages = self.languages.replace(" ", "")
+        super(Newsletter, self).save(*args, **kwargs)
+
+        # Cannot import earlier due to circular import
+        from news.newsletters import clear_newsletter_cache
+
+        # Newsletter data might have changed, forget our cached version of it
+        clear_newsletter_cache()
+
+    @property
+    def welcome_id(self):
+        """Return newsletter's welcome message ID, or the default one"""
+        return self.welcome or settings.DEFAULT_WELCOME_MESSAGE_ID

--- a/apps/news/urls.py
+++ b/apps/news/urls.py
@@ -1,7 +1,8 @@
-from django.conf.urls.defaults import *
+from django.conf.urls.defaults import patterns, url
 from views import (subscribe, subscribe_sms, unsubscribe, user, confirm,
                    debug_user, custom_unsub_reason, custom_student_reps,
-                   custom_update_phonebook)
+                   custom_update_phonebook, newsletters)
+
 
 urlpatterns = patterns('',
     url('^subscribe/$', subscribe),
@@ -14,4 +15,6 @@ urlpatterns = patterns('',
     url('^custom_unsub_reason/$', custom_unsub_reason),
     url('^custom_student_reps/$', custom_student_reps),
     url('^custom_update_phonebook/(.*)/$', custom_update_phonebook),
+
+    url('^newsletters/$', newsletters, name='newsletters_api'),
 )

--- a/settings.py
+++ b/settings.py
@@ -145,6 +145,12 @@ EMAIL_BACKLOG_TOLERANCE = 200
 SYNC_UNSUBSCRIBE_LIMIT = 1000
 LDAP_TIMEOUT = 2
 
+# Default newsletter welcome message ID for HTML format.
+# There must also exist a text-format message with the same
+# ID with "_T" appended, e.g. "39_T"
+DEFAULT_WELCOME_MESSAGE_ID = '39'
+
+
 def JINJA_CONFIG():
     import jinja2
     from django.conf import settings
@@ -174,3 +180,15 @@ CELERY_IGNORE_RESULT = True
 
 import djcelery
 djcelery.setup_loader()
+
+CACHES = {
+    # We're not using it, but Django insists that we define a 'default' cache
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+    'newsletters': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'newsletters',
+        'TIMEOUT': 3600,   # cache is cleared when newsletters are changed
+    }
+}

--- a/settings_ex.py
+++ b/settings_ex.py
@@ -2,13 +2,15 @@ from settings import *
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': '',                      # Or path to database file if using sqlite3.
+        # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3'
+        # or 'oracle'.
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': '',        # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
-        'OPTIONS':  {'init_command': 'SET storage_engine=InnoDB'},
+        'HOST': '',  # Set to empty string for localhost. Not used with sqlite3
+        'PORT': '',  # Set to empty string for default. Not used with sqlite3.
+        'OPTIONS': {'init_command': 'SET storage_engine=InnoDB'},
     }
 }
 
@@ -43,3 +45,6 @@ LDAP = {
     'password': '',
     'search_base': 'o=com,dc=mozilla',
 }
+
+EXACTTARGET_USER = ''
+EXACTTARGET_PASS = ''


### PR DESCRIPTION
- Add database models to store information about newsletters, e.g. name,
  description, whether active, supported languages, etc.
- Add an API call to fetch that information.
- Bug 841426 (https://bugzilla.mozilla.org/show_bug.cgi?id=841426)
