### PR TITLE
Remove non-existent newsletters from fixture

### DIFF
--- a/apps/news/admin.py
+++ b/apps/news/admin.py
@@ -14,7 +14,7 @@ admin.site.register(Subscriber, SubscriberAdmin)
 
 class NewsletterAdmin(admin.ModelAdmin):
     list_display = ['title', 'show', 'active', 'description', 'welcome',
-                    'languages']
+                    'languages', 'vendor_id']
 
 
 admin.site.register(Newsletter, NewsletterAdmin)

--- a/apps/news/fixtures/newsletters.json
+++ b/apps/news/fixtures/newsletters.json
@@ -194,21 +194,7 @@
       "title": "About Labs", 
       "slug": "labs"
     }
-  }, 
-  {
-    "pk": 10, 
-    "model": "news.newsletter", 
-    "fields": {
-      "vendor_id": "n/a", 
-      "description": "", 
-      "show": false, 
-      "welcome": "", 
-      "languages": "en-US", 
-      "active": false, 
-      "title": "QA News", 
-      "slug": "qa-news"
-    }
-  }, 
+  },
   {
     "pk": 12, 
     "model": "news.newsletter", 
@@ -221,20 +207,6 @@
       "active": false, 
       "title": "About Standards", 
       "slug": "about-standards"
-    }
-  }, 
-  {
-    "pk": 13, 
-    "model": "news.newsletter", 
-    "fields": {
-      "vendor_id": "MOBILE_ADDON_DEV", 
-      "description": "", 
-      "show": false, 
-      "welcome": "", 
-      "languages": "en-US", 
-      "active": false, 
-      "title": "Mobile Addon Development", 
-      "slug": "mobile-addon-dev"
     }
   }, 
   {


### PR DESCRIPTION
- Remove newsletters from fixture if they're not in ET
- Show the vendor_id in the admin so we notice next time if we have
  newsletters without vendor IDs.

Bug 841426
