### PR TITLE
Clear newsletter cache on delete

### DIFF
--- a/apps/news/models.py
+++ b/apps/news/models.py
@@ -2,6 +2,8 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.db import models
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 
 
 class SubscriberManager(models.Manager):
@@ -87,3 +89,10 @@ class Newsletter(models.Model):
     def welcome_id(self):
         """Return newsletter's welcome message ID, or the default one"""
         return self.welcome or settings.DEFAULT_WELCOME_MESSAGE_ID
+
+
+@receiver(post_delete, sender=Newsletter)
+def post_newsletter_delete(sender, **kwargs):
+    # Cannot import earlier due to circular import
+    from news.newsletters import clear_newsletter_cache
+    clear_newsletter_cache()

--- a/apps/news/tests.py
+++ b/apps/news/tests.py
@@ -420,3 +420,20 @@ class TestNewslettersAPI(TestCase):
         )
         vendor_ids2 = set(newsletter_fields())
         self.assertEqual(set([u'VEND1', u'VEND2']), vendor_ids2)
+
+    def test_cache_clear_on_delete(self):
+        # Our caching of newsletter data doesn't result in wrong answers
+        # when newsletters are deleted
+        nl1 = models.Newsletter.objects.create(
+            slug='slug',
+            title='title',
+            vendor_id='VEND1',
+            active=False,
+            languages='en-US, fr, de ',
+            )
+        vendor_ids = newsletter_fields()
+        self.assertEqual([u'VEND1'], vendor_ids)
+        # Now delete it
+        nl1.delete()
+        vendor_ids = newsletter_fields()
+        self.assertEqual([], vendor_ids)


### PR DESCRIPTION
When we delete newsletters, we need to clear the newsletter cache.
Use the post_delete signal.

Bug 841426
