### PR TITLE
Use default cache

### DIFF
--- a/apps/news/tests.py
+++ b/apps/news/tests.py
@@ -398,6 +398,22 @@ class TestNewslettersAPI(TestCase):
         nl1 = models.Newsletter.objects.get(id=nl1.id)
         self.assertEqual('en-US,fr,de', nl1.languages)
 
+    def test_newsletters_cached(self):
+        models.Newsletter.objects.create(
+            slug='slug',
+            title='title',
+            vendor_id='VEND1',
+            active=False,
+            languages='en-US, fr, de ',
+            )
+        # This should get the data cached
+        newsletter_fields()
+        # Now request it again and it shouldn't have to generate the
+        # data from scratch.
+        with patch('news.newsletters._get_newsletters_data') as get:
+            newsletter_fields()
+        self.assertFalse(get.called)
+
     def test_cache_clearing(self):
         # Our caching of newsletter data doesn't result in wrong answers
         # when newsletters change

--- a/settings.py
+++ b/settings.py
@@ -182,13 +182,7 @@ import djcelery
 djcelery.setup_loader()
 
 CACHES = {
-    # We're not using it, but Django insists that we define a 'default' cache
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
-    'newsletters': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'newsletters',
-        'TIMEOUT': 3600,   # cache is cleared when newsletters are changed
-    }
 }


### PR DESCRIPTION
Instead of requiring configuration of a separate cache for the
newsletter data, use the default cache.

Bug 841426
