### PR TITLE
Bug 863066: Changes for Firefox OS newsletter launch

### DIFF
--- a/apps/news/backends/common.py
+++ b/apps/news/backends/common.py
@@ -7,3 +7,11 @@ class UnauthorizedException(Exception):
 class NewsletterException(Exception):
     """Error when trying to talk to the the email server."""
     pass
+
+
+class NewsletterNoResultsException(NewsletterException):
+    """
+    No results were returned from the mail server (but the request
+    didn't report any errors)
+    """
+    pass

--- a/apps/news/migrations/0003_auto__add_field_newsletter_requires_double_optin.py
+++ b/apps/news/migrations/0003_auto__add_field_newsletter_requires_double_optin.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Newsletter.requires_double_optin'
+        db.add_column('news_newsletter', 'requires_double_optin',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Newsletter.requires_double_optin'
+        db.delete_column('news_newsletter', 'requires_double_optin')
+
+
+    models = {
+        'news.newsletter': {
+            'Meta': {'object_name': 'Newsletter'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'languages': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'requires_double_optin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'vendor_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'welcome': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'})
+        },
+        'news.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'primary_key': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'default': "'0b1108ee-4a68-48b3-9481-3e81ec586f9e'", 'max_length': '40', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['news']

--- a/apps/news/models.py
+++ b/apps/news/models.py
@@ -19,6 +19,8 @@ class SubscriberManager(models.Manager):
         if not created and sub.token != token:
             sub.token = token
             sub.save()
+            # FIXME: this could mean there's another record in Exact Target
+            # with the other token
 
         return sub
 
@@ -70,6 +72,10 @@ class Newsletter(models.Model):
         max_length=200,
         help_text="Comma-separated list of the language codes that this "
                   "newsletter supports",
+    )
+    requires_double_optin = models.BooleanField(
+        help_text="True if subscribing to this newsletter requires someone"
+                  "to respond to a confirming email.",
     )
 
     def __unicode__(self):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ ipython==0.10
 
 -e git://github.com/jbalogh/test-utils.git#egg=test-utils
 -e git://github.com/jbalogh/django-nose.git#egg=django_nose
-nose==0.11.1
+nose==1.3.0
 coverage==3.2b4
 mock==0.6.0
 

--- a/settings.py
+++ b/settings.py
@@ -152,6 +152,10 @@ RESPONSYS_PASS = ''
 RESPONSYS_FOLDER = '!MasterData'
 RESPONSYS_LIST = 'TEST_CONTACTS_LIST'
 
+
+# Name of the database where we put someone's token when they confirm
+EXACTTARGET_CONFIRMATION = 'Confirmation'
+
 # This is a token that bypasses the news app auth in certain ways to
 # make debugging easier
 # SUPERTOKEN = <token>

--- a/settings_ex.py
+++ b/settings_ex.py
@@ -44,9 +44,15 @@ LDAP = {
     'search_base': 'o=com,dc=mozilla',
 }
 
+#: Credentials for Exact Target account
 EXACTTARGET_USER = ''
 EXACTTARGET_PASS = ''
+#: Name of the database of people who have confirmed
 EXACTTARGET_DATA = ''
+#: Name of the database of people waiting for confirmation
+EXACTTARGET_OPTIN_STAGE = ''
+# Name of the database where we put someone's token when they confirm
+EXACTTARGET_CONFIRMATION = 'Confirmation'
 
 LOGGING['root'] = {
     'level': 'DEBUG',


### PR DESCRIPTION
Note to @pmclanahan: We've settled the design and this PR implements it, as far as I can tell. Ready to review.

I've refactored some of the code to make the logic clearer, so please check this out.
- Check both Master_Subscribers and OPT_IN before concluding a user
  does not exist in Exact Target
- Make more explicit behavior on subscribing in various
  cases
- Add support for translated welcome messages
- More tests
- Other refactoring and cleanup

Bug 863066
