### PR TITLE
Bug 874616: Validate newsletter language

### DIFF
--- a/apps/news/models.py
+++ b/apps/news/models.py
@@ -97,6 +97,11 @@ class Newsletter(models.Model):
         """Return newsletter's welcome message ID, or the default one"""
         return self.welcome or settings.DEFAULT_WELCOME_MESSAGE_ID
 
+    @property
+    def language_list(self):
+        """Return language codes for this newsletter as a list"""
+        return [x.strip() for x in self.languages.split(",")]
+
 
 @receiver(post_delete, sender=Newsletter)
 def post_newsletter_delete(sender, **kwargs):

--- a/apps/news/newsletters.py
+++ b/apps/news/newsletters.py
@@ -77,7 +77,18 @@ def newsletter_names():
 
 def newsletter_fields():
     """Get a list of all the newsletter backend-specific fields"""
-    return  _newsletters()['by_vendor_id'].keys()
+    return _newsletters()['by_vendor_id'].keys()
+
+
+def newsletter_languages():
+    """
+    Return a set of the 2 or 5 char codes of all the languages
+    supported by newsletters.
+    """
+    lang_set = set()
+    for newsletter in _newsletters()['by_name'].values():
+        lang_set |= set(newsletter.language_list)
+    return lang_set
 
 
 def clear_newsletter_cache():


### PR DESCRIPTION
In the basket API, validate that incoming languages are either
blank or one of the languages supported by some newsletter.
