### PR TITLE
Bug 865058: Add order field to newsletters

### DIFF
--- a/apps/news/admin.py
+++ b/apps/news/admin.py
@@ -14,9 +14,11 @@ admin.site.register(Subscriber, SubscriberAdmin)
 
 class NewsletterAdmin(admin.ModelAdmin):
     fields = ('title', 'slug', 'vendor_id', 'welcome', 'description',
-              'languages', 'show', 'active', 'requires_double_optin')
-    list_display = ('title', 'slug', 'vendor_id', 'welcome',
+              'languages', 'show', 'order', 'active', 'requires_double_optin')
+    list_display = ('order', 'title', 'slug', 'vendor_id', 'welcome',
                     'languages', 'show', 'active', 'requires_double_optin')
+    list_display_links = ('title', 'slug')
+    list_editable = ('order', 'show', 'active', 'requires_double_optin')
     list_filter = ('show', 'active', 'requires_double_optin')
     prepopulated_fields = {"slug": ("title",)}
     search_fields = ('title', 'slug', 'description', 'vendor_id')

--- a/apps/news/migrations/0004_auto__add_field_newsletter_order.py
+++ b/apps/news/migrations/0004_auto__add_field_newsletter_order.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Newsletter.order'
+        db.add_column('news_newsletter', 'order',
+                      self.gf('django.db.models.fields.IntegerField')(default=0),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Newsletter.order'
+        db.delete_column('news_newsletter', 'order')
+
+
+    models = {
+        'news.newsletter': {
+            'Meta': {'ordering': "['order']", 'object_name': 'Newsletter'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'languages': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'requires_double_optin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'vendor_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'welcome': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'})
+        },
+        'news.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'primary_key': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'default': "'3e17e1c3-0543-411b-a6d4-5714e9dd2a48'", 'max_length': '40', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['news']

--- a/apps/news/models.py
+++ b/apps/news/models.py
@@ -80,9 +80,17 @@ class Newsletter(models.Model):
         help_text="True if subscribing to this newsletter requires someone"
                   "to respond to a confirming email.",
     )
+    order = models.IntegerField(
+        default=0,
+        help_text="Order to display the newsletters on the web site. "
+                  "Newsletters with lower order numbers will display first."
+    )
 
     def __unicode__(self):
         return self.title
+
+    class Meta(object):
+        ordering = ['order']
 
     def save(self, *args, **kwargs):
         # Strip whitespace from langs before save


### PR DESCRIPTION
Add an `order` field to newsletters. Bedrock already has code on the
newsletter preference center page so that if the newsletters include
an `order` field, they'll be sorted by that for display, instead of
by the title.

Also update the admin config to make it easier to work with the order
fields, by making them editable right in the display list.  Add a
few other fields to that for good measure.
