### PR TITLE
Bug 863066: Fix subscription data returned

### DIFF
--- a/apps/news/newsletters.py
+++ b/apps/news/newsletters.py
@@ -70,9 +70,17 @@ def newsletter_name(field):
         return None
 
 
-def newsletter_names():
-    """Get a list of all the available newsletters"""
+def newsletter_slugs():
+    """
+    Get a list of all the available newsletters.
+    Returns a list of their slugs.
+    """
     return _newsletters()['by_name'].keys()
+
+
+def slug_to_vendor_id(slug):
+    """Given a newsletter's slug, return its vendor_id"""
+    return _newsletters()['by_name'][slug].vendor_id
 
 
 def newsletter_fields():

--- a/apps/news/tasks.py
+++ b/apps/news/tasks.py
@@ -13,7 +13,7 @@ from celery.task import Task, task
 
 from .backends.exacttarget import (ExactTarget, ExactTargetDataExt)
 from .models import Newsletter
-from .newsletters import newsletter_field, newsletter_names
+from .newsletters import newsletter_field, newsletter_slugs
 
 
 log = logging.getLogger(__name__)
@@ -176,7 +176,7 @@ def parse_newsletters(record, type, newsletters, cur_newsletters):
                 unsubs = cur_newsletters - set(newsletters)
             else:
                 subs = set(newsletters)
-                all = set(newsletter_names())
+                all = set(newsletter_slugs())
                 unsubs = all - subs
         else:  # type == UNSUBSCRIBE
             # unsubscribe from the specified newsletters


### PR DESCRIPTION
There was a bug in how we translated from what Exact Target gives us
to our preferred internal representation of what newsletters the user
is subscribed to. The symptom was that when a user confirmed, we
thought they hadn't subscribed to anything and so didn't send any
welcome messages.
