### PR TITLE
Bug 863033: Three basket fixes

### DIFF
--- a/apps/news/tasks.py
+++ b/apps/news/tasks.py
@@ -253,8 +253,6 @@ def update_user(data, email, token, created, type, optin):
         'EMAIL_PERMISSION_STATUS_': 'I',
         'MODIFIED_DATE_': gmttime(),
     }
-    if created:
-        record['CREATED_DATE_'] = gmttime()
 
     extra_fields = {
         'country': 'COUNTRY_',
@@ -292,6 +290,14 @@ def update_user(data, email, token, created, type, optin):
         msg = "Some error with Exact Target: %r" % user_data
         log.error(msg)
         raise RetryTask(msg)
+
+    if lang:
+        # User asked for a language change. Use the new language from
+        # here on.
+        user_data['lang'] = lang
+    else:
+        # Use `lang` as a shorter reference to user_data['lang']
+        lang = user_data['lang']
 
     # We need an HTML/Text format choice for sending welcome messages, and
     # optionally to update their ET record

--- a/apps/news/tests.py
+++ b/apps/news/tests.py
@@ -1313,6 +1313,40 @@ class TestLookForUser(TestCase):
         }
         self.assertEqual(expected_result, result)
 
+    def test_unset_lang(self):
+        """
+        If lang is not set in ET, look_for_user returns '', not None.
+        """
+        # ET returns None if the database has NULL.
+        Newsletter.objects.create(slug='n1', vendor_id='NEWSLETTER1')
+        Newsletter.objects.create(slug='n2', vendor_id='NEWSLETTER2')
+        fields = ['NEWSLETTER1_FLG', 'NEWSLETTER2_FLG']
+        with patch('news.views.ExactTargetDataExt') as et_ext:
+            data_ext = et_ext()
+            data_ext.get_record.return_value = {
+                'EMAIL_ADDRESS_': 'dude@example.com',
+                'EMAIL_FORMAT_': 'HTML',
+                'COUNTRY_': 'us',
+                'LANGUAGE_ISO2': None,
+                'TOKEN': 'asdf',
+                'CREATED_DATE_': 'Yesterday',
+                'NEWSLETTER1_FLG': 'Y',
+                'NEWSLETTER2_FLG': 'Y',
+            }
+            result = look_for_user(database='DUMMY', email='EMAIL',
+                                   token='TOKEN', fields=fields)
+        expected_result = {
+            'newsletters': [u'n1', u'n2'],
+            'status': 'ok',
+            'country': 'us',
+            'lang': '',
+            'token': 'asdf',
+            'created-date': 'Yesterday',
+            'email': 'dude@example.com',
+            'format': 'HTML',
+        }
+        self.assertEqual(expected_result, result)
+
 
 class TestGetUserData(TestCase):
 

--- a/apps/news/views.py
+++ b/apps/news/views.py
@@ -211,9 +211,9 @@ def look_for_user(database, email, token, fields):
     user_data = {
         'status': 'ok',
         'email': user['EMAIL_ADDRESS_'],
-        'format': user['EMAIL_FORMAT_'],
-        'country': user['COUNTRY_'],
-        'lang': user['LANGUAGE_ISO2'],
+        'format': user['EMAIL_FORMAT_'] or 'H',
+        'country': user['COUNTRY_'] or '',
+        'lang': user['LANGUAGE_ISO2'] or '',  # Never None
         'token': user['TOKEN'],
         'created-date': user['CREATED_DATE_'],
         'newsletters': newsletters,


### PR DESCRIPTION
1) When language, country, or format is not yet set in ET, the database
   there will have NULL and ET will return None. Fix that to '' so
   we can use it later without worrying about whether it's None.
2) Only set CREATED_DATE_ in ET when we create a new user in ET, not
   when we create a new user in Basket.
3) When the user changes languages and subscribes to things at the same
   time, use the new language they chose when sending their welcome
   messages.
