### PR TITLE
Fix no lang on new user in some cases

### DIFF
--- a/apps/news/tasks.py
+++ b/apps/news/tasks.py
@@ -265,7 +265,7 @@ def update_user(data, email, token, created, type, optin):
         if field in data:
             record[extra_fields[field]] = data[field]
 
-    lang = record.get('LANGUAGE_ISO2', None)
+    lang = record.get('LANGUAGE_ISO2', '') or ''
 
     # Can't import this earlier, circular import
     from .views import get_user_data


### PR DESCRIPTION
If we were creating a new ET user in update_user, and
whatever form they submitted didn't have a lang included,
we were ending up passing a None lang to send_welcomes.
