### PR TITLE
Bug 823987: require double opt-in for EN newsletter subscriptions

### DIFF
--- a/news/migrations/0005_auto__add_field_newsletter_confirm_message.py
+++ b/news/migrations/0005_auto__add_field_newsletter_confirm_message.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Newsletter.confirm_message'
+        db.add_column('news_newsletter', 'confirm_message',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=64, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Newsletter.confirm_message'
+        db.delete_column('news_newsletter', 'confirm_message')
+
+
+    models = {
+        'news.newsletter': {
+            'Meta': {'ordering': "['order']", 'object_name': 'Newsletter'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'confirm_message': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'languages': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'requires_double_optin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'vendor_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'welcome': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'})
+        },
+        'news.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'primary_key': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'default': "'52afba50-b939-4ac7-914f-e5823cafea68'", 'max_length': '40', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['news']

--- a/news/models.py
+++ b/news/models.py
@@ -64,7 +64,7 @@ class Newsletter(models.Model):
         help_text="The ID of the welcome message sent for this newsletter. "
                   "This is the HTML version of the message; append _T to this "
                   "ID to get the ID of the text-only version.  If blank, "
-                  "default is %s." % settings.DEFAULT_WELCOME_MESSAGE_ID,
+                  "no welcome is sent",
         blank=True,
     )
     vendor_id = models.CharField(
@@ -85,6 +85,14 @@ class Newsletter(models.Model):
         help_text="Order to display the newsletters on the web site. "
                   "Newsletters with lower order numbers will display first."
     )
+    confirm_message = models.CharField(
+        max_length=64,
+        help_text="The ID of the confirm message sent for this newsletter."
+                  "That's the one that says 'please click here to confirm'."
+                  "If blank, a default message based on the user's language "
+                  "is sent.",
+        blank=True,
+    )
 
     def __unicode__(self):
         return self.title
@@ -94,7 +102,10 @@ class Newsletter(models.Model):
 
     def save(self, *args, **kwargs):
         # Strip whitespace from langs before save
+        # Also confirm_message or welcome
         self.languages = self.languages.replace(" ", "")
+        self.welcome = self.welcome.strip()
+        self.confirm_message = self.confirm_message.strip()
         super(Newsletter, self).save(*args, **kwargs)
 
         # Cannot import earlier due to circular import

--- a/news/tests/test_confirm.py
+++ b/news/tests/test_confirm.py
@@ -151,7 +151,7 @@ class TestConfirmationLogic(TestCase):
     #
 
     def test_pending_english_required(self):
-        # Should exempt them and confirm them
+        # Should NOT exempt them and confirm them
         self.check_confirmation(user_in_basket=False,
                                 user_in_master=False,
                                 user_in_optin=True,
@@ -160,7 +160,7 @@ class TestConfirmationLogic(TestCase):
                                 newsletter_without_required_confirmation=False,
                                 is_english=True,
                                 type=SUBSCRIBE,
-                                expected_result=UU_EXEMPT_PENDING)
+                                expected_result=UU_MUST_CONFIRM_PENDING)
 
     def test_pending_english_not_required(self):
         # Should exempt them and confirm them

--- a/news/tests/test_send_confirm_notice.py
+++ b/news/tests/test_send_confirm_notice.py
@@ -1,0 +1,139 @@
+from django.test import TestCase
+
+from mock import patch
+
+from news.models import Newsletter
+from news.tasks import send_confirm_notice, CONFIRM_SENDS, BasketError
+
+
+@patch('news.tasks.send_message', autospec=True)
+class TestSendConfirmNotice(TestCase):
+    """Test send_confirm_notice method"""
+
+    def setUp(self):
+        self.email = "user@example.com"
+        self.token = "LKDFJLKSDJFLSKDFJ"
+        self.newsletter1 = Newsletter.objects.create(
+            slug='slug1',
+            vendor_id='VENDOR1',
+            confirm_message='confirm1',
+            languages='en'
+        )
+        self.newsletter2 = Newsletter.objects.create(
+            slug='slug2',
+            vendor_id='VENDOR2',
+        )
+
+    # default confirmation notice (no custom notice for newsletter)
+    ## known short lang
+
+    def test_default_confirm_notice_H(self, send_message):
+        """Test newsletter that has no explicit confirm"""
+        send_confirm_notice(self.email, self.token, "es", "H", ['slug2'])
+        expected_message = CONFIRM_SENDS["es"]
+        send_message.assert_called_with(expected_message,
+                                        self.email,
+                                        self.token,
+                                        'H')
+
+    def test_default_confirm_notice_T(self, send_message):
+        """Test newsletter that has no explicit confirm"""
+        send_confirm_notice(self.email, self.token, "es", "T", ['slug2'])
+        expected_message = CONFIRM_SENDS["es"] + "_T"
+        send_message.assert_called_with(expected_message,
+                                        self.email,
+                                        self.token,
+                                        'T')
+
+    ### known long lang
+
+    def test_default_confirm_notice_long_lang_H(self, send_message):
+        """Test newsletter that has no explicit confirm with long lang code"""
+        send_confirm_notice(self.email, self.token, "es-ES", "H", ['slug2'])
+        expected_message = CONFIRM_SENDS["es"]
+        send_message.assert_called_with(expected_message,
+                                        self.email,
+                                        self.token,
+                                        'H')
+
+    def test_default_confirm_notice_long_lang_T(self, send_message):
+        """Test newsletter that has no explicit confirm with long lang code"""
+        send_confirm_notice(self.email, self.token, "es-ES", "T", ['slug2'])
+        expected_message = CONFIRM_SENDS["es"] + "_T"
+        send_message.assert_called_with(expected_message,
+                                        self.email,
+                                        self.token,
+                                        'T')
+
+    ### bad lang
+
+    def test_default_confirm_notice_bad_lang_H(self, send_message):
+        """Test when there's no default confirm notice for a language"""
+        with self.assertRaises(BasketError):
+            send_confirm_notice(self.email, self.token, "zz", "H", ['slug2'])
+        with self.assertRaises(BasketError):
+            send_confirm_notice(self.email, self.token, "zz-Z", "H", ['slug2'])
+
+    def test_default_confirm_notice_bad_lang_T(self, send_message):
+        """Test when newsletter uses default notice and the lang is unknown"""
+        with self.assertRaises(BasketError):
+            send_confirm_notice(self.email, self.token, "zz", "T", ['slug2'])
+        with self.assertRaises(BasketError):
+            send_confirm_notice(self.email, self.token, "zz-Z", "T", ['slug2'])
+
+    # explicit (custom) confirmation notice for newsletter
+    ### known short lang
+
+    def test_explicit_confirm_notice_H(self, send_message):
+        """Test newsletter that has explicit confirm message"""
+        send_confirm_notice(self.email, self.token, "en", "H", ['slug1'])
+        expected_message = 'en_confirm1'
+        send_message.assert_called_with(expected_message,
+                                        self.email,
+                                        self.token,
+                                        'H')
+
+    def test_explicit_confirm_notice_T(self, send_message):
+        """Test newsletter that has explicit confirm message"""
+        send_confirm_notice(self.email, self.token, "en", "T", ['slug1'])
+        expected_message = 'en_confirm1_T'
+        send_message.assert_called_with(expected_message,
+                                        self.email,
+                                        self.token,
+                                        'T')
+
+    ### known long lang
+
+    def test_explicit_confirm_notice_long_lang_H(self, send_message):
+        """Test newsletter that has explicit confirm message with long lang"""
+        send_confirm_notice(self.email, self.token, "en-US", "H", ['slug1'])
+        expected_message = 'en_confirm1'
+        send_message.assert_called_with(expected_message,
+                                        self.email,
+                                        self.token,
+                                        'H')
+
+    def test_explicit_confirm_notice_long_lang_T(self, send_message):
+        """Test newsletter that has explicit confirm message with long lang"""
+        send_confirm_notice(self.email, self.token, "en-US", "T", ['slug1'])
+        expected_message = 'en_confirm1_T'
+        send_message.assert_called_with(expected_message,
+                                        self.email,
+                                        self.token,
+                                        'T')
+
+    ### bad lang
+
+    def test_explicit_confirm_notice_bad_lang_H(self, send_message):
+        """Test when newsletter uses explicit notice and the lang is unknown"""
+        with self.assertRaises(BasketError):
+            send_confirm_notice(self.email, self.token, "zz", "H", ['slug1'])
+        with self.assertRaises(BasketError):
+            send_confirm_notice(self.email, self.token, "zz-Z", "H", ['slug1'])
+
+    def test_explicit_confirm_notice_bad_lang_T(self, send_message):
+        """Test when newsletter uses explicit notice and the lang is unknown"""
+        with self.assertRaises(BasketError):
+            send_confirm_notice(self.email, self.token, "zz", "T", ['slug1'])
+        with self.assertRaises(BasketError):
+            send_confirm_notice(self.email, self.token, "zz-Z", "T", ['slug1'])

--- a/news/tests/test_send_welcomes.py
+++ b/news/tests/test_send_welcomes.py
@@ -1,0 +1,218 @@
+from django.test import TestCase
+
+from mock import patch
+
+from news.models import Newsletter
+from news.tasks import mogrify_message_id, confirm_user
+
+
+class TestSendWelcomes(TestCase):
+
+    def test_mogrify_message_id_text(self):
+        """Test adding lang and text format to message ID"""
+        result = mogrify_message_id("MESSAGE", "en", "T")
+        expect = "en_MESSAGE_T"
+        self.assertEqual(expect, result)
+
+    def test_mogrify_message_id_html(self):
+        """Test adding lang and html format to message ID"""
+        result = mogrify_message_id("MESSAGE", "en", "H")
+        expect = "en_MESSAGE"
+        self.assertEqual(expect, result)
+
+    def test_mogrify_message_id_no_lang(self):
+        """Test adding no lang and format to message ID"""
+        result = mogrify_message_id("MESSAGE", None, "T")
+        expect = "MESSAGE_T"
+        self.assertEqual(expect, result)
+
+    def test_mogrify_message_id_long_lang(self):
+        """Test adding long lang and format to message ID"""
+        result = mogrify_message_id("MESSAGE", "en-US", "T")
+        expect = "en_MESSAGE_T"
+        self.assertEqual(expect, result)
+
+    def test_mogrify_message_id_upcase_lang(self):
+        """Test adding uppercase lang and format to message ID"""
+        result = mogrify_message_id("MESSAGE", "FR", "T")
+        expect = "fr_MESSAGE_T"
+        self.assertEqual(expect, result)
+
+    @patch('news.tasks.send_message')
+    @patch('news.tasks.apply_updates')
+    def test_text_welcome(self, apply_updates, send_message):
+        """Test sending the right welcome message"""
+        welcome = u'welcome'
+        Newsletter.objects.create(
+            slug='slug',
+            vendor_id='VENDOR',
+            welcome=welcome,
+            languages='en,ru',
+        )
+        token = "TOKEN"
+        email = 'dude@example.com'
+        lang = 'ru'
+        format = 'T'
+        # User who prefers Russian Text messages
+        user_data = {
+            'status': 'ok',
+            'confirmed': False,
+            'newsletters': ['slug'],
+            'format': format,
+            'lang': lang,
+            'token': token,
+            'email': email,
+        }
+        confirm_user(token, user_data)
+        expected_welcome = "%s_%s_%s" % (lang, welcome, format)
+        send_message.assert_called_with(expected_welcome, email, token, format)
+
+    @patch('news.tasks.send_message')
+    @patch('news.tasks.apply_updates')
+    def test_html_welcome(self, apply_updates, send_message):
+        """Test sending the right welcome message"""
+        welcome = u'welcome'
+        Newsletter.objects.create(
+            slug='slug',
+            vendor_id='VENDOR',
+            welcome=welcome,
+            languages='en,ru',
+        )
+        token = "TOKEN"
+        email = 'dude@example.com'
+        lang = 'RU'  # This guy had an uppercase lang code for some reason
+        format = 'H'
+        # User who prefers Russian HTML messages
+        user_data = {
+            'status': 'ok',
+            'confirmed': False,
+            'newsletters': ['slug'],
+            'format': format,
+            'lang': lang,
+            'token': token,
+            'email': email,
+        }
+        confirm_user(token, user_data)
+        # Lang code is lowercased. And we don't append anything for HTML.
+        expected_welcome = "%s_%s" % (lang.lower(), welcome)
+        send_message.assert_called_with(expected_welcome, email, token, format)
+
+    @patch('news.tasks.send_message')
+    @patch('news.tasks.apply_updates')
+    def test_bad_lang_welcome(self, apply_updates, send_message):
+        """Test sending welcome in english if user wants a lang that
+        our newsletter doesn't support"""
+        welcome = u'welcome'
+        Newsletter.objects.create(
+            slug='slug',
+            vendor_id='VENDOR',
+            welcome=welcome,
+            languages='en,ru',
+        )
+        token = "TOKEN"
+        email = 'dude@example.com'
+        lang = 'fr'
+        format = 'H'
+        # User who prefers French HTML messages
+        user_data = {
+            'status': 'ok',
+            'confirmed': False,
+            'newsletters': ['slug'],
+            'format': format,
+            'lang': lang,
+            'token': token,
+            'email': email,
+        }
+        confirm_user(token, user_data)
+        # They're getting English. And we don't append anything for HTML.
+        expected_welcome = "en_%s" % welcome
+        send_message.assert_called_with(expected_welcome, email, token, format)
+
+    @patch('news.tasks.send_message')
+    @patch('news.tasks.apply_updates')
+    def test_long_lang_welcome(self, apply_updates, send_message):
+        """Test sending welcome in pt if the user wants pt and the newsletter
+        supports pt-Br"""
+        welcome = u'welcome'
+        Newsletter.objects.create(
+            slug='slug',
+            vendor_id='VENDOR',
+            welcome=welcome,
+            languages='en,ru,pt-Br',
+        )
+        token = "TOKEN"
+        email = 'dude@example.com'
+        lang = 'pt'
+        format = 'H'
+        user_data = {
+            'status': 'ok',
+            'confirmed': False,
+            'newsletters': ['slug'],
+            'format': format,
+            'lang': lang,
+            'token': token,
+            'email': email,
+        }
+        confirm_user(token, user_data)
+        # They're getting pt. And we don't append anything for HTML.
+        expected_welcome = "pt_%s" % welcome
+        send_message.assert_called_with(expected_welcome, email, token, format)
+
+    @patch('news.tasks.send_message')
+    @patch('news.tasks.apply_updates')
+    def test_other_long_lang_welcome(self, apply_updates, send_message):
+        """Test sending welcome in pt if the user wants pt-Br and the
+        newsletter supports pt"""
+        welcome = u'welcome'
+        Newsletter.objects.create(
+            slug='slug',
+            vendor_id='VENDOR',
+            welcome=welcome,
+            languages='en,ru,pt',
+        )
+        token = "TOKEN"
+        email = 'dude@example.com'
+        lang = 'pt-Br'
+        format = 'H'
+        user_data = {
+            'status': 'ok',
+            'confirmed': False,
+            'newsletters': ['slug'],
+            'format': format,
+            'lang': lang,
+            'token': token,
+            'email': email,
+        }
+        confirm_user(token, user_data)
+        # They're getting pt. And we don't append anything for HTML.
+        expected_welcome = "pt_%s" % welcome
+        send_message.assert_called_with(expected_welcome, email, token, format)
+
+    @patch('news.tasks.send_message')
+    @patch('news.tasks.apply_updates')
+    def test_one_lang_welcome(self, apply_updates, send_message):
+        """If a newsletter only has one language, the welcome message
+        still gets a language prefix"""
+        welcome = u'welcome'
+        Newsletter.objects.create(
+            slug='slug',
+            vendor_id='VENDOR',
+            welcome=welcome,
+            languages='en',
+        )
+        token = "TOKEN"
+        email = 'dude@example.com'
+        lang = 'pt-Br'
+        format = 'H'
+        user_data = {
+            'status': 'ok',
+            'confirmed': False,
+            'newsletters': ['slug'],
+            'format': format,
+            'lang': lang,
+            'token': token,
+            'email': email,
+        }
+        confirm_user(token, user_data)
+        expected_welcome = 'en_' + welcome
+        send_message.assert_called_with(expected_welcome, email, token, format)


### PR DESCRIPTION
- Don't use language to exempt any subscribers from having to confirm
- Add a field to basket newsletters to allow them to specify a message
  to use for confirmations
