### PR TITLE
Bug 852965 - add secure API to look up users

### DIFF
--- a/news/admin.py
+++ b/news/admin.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
 
-from .models import Newsletter, Subscriber
+from .models import APIUser, Newsletter, Subscriber
+
+
+class APIUserAdmin(admin.ModelAdmin):
+    list_display = ('name', 'enabled')
+
+
+admin.site.register(APIUser, APIUserAdmin)
 
 
 class SubscriberAdmin(admin.ModelAdmin):

--- a/news/migrations/0006_auto__add_apiuser.py
+++ b/news/migrations/0006_auto__add_apiuser.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'APIUser'
+        db.create_table('news_apiuser', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=256)),
+            ('api_key', self.gf('django.db.models.fields.CharField')(default='fa8347f2-14fe-45db-a62f-4d6e4d88b62e', max_length=40, db_index=True)),
+            ('enabled', self.gf('django.db.models.fields.BooleanField')(default=True)),
+        ))
+        db.send_create_signal('news', ['APIUser'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'APIUser'
+        db.delete_table('news_apiuser')
+
+
+    models = {
+        'news.apiuser': {
+            'Meta': {'object_name': 'APIUser'},
+            'api_key': ('django.db.models.fields.CharField', [], {'default': "'e420aec3-106f-4b17-9126-43a1356504d8'", 'max_length': '40', 'db_index': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'news.newsletter': {
+            'Meta': {'ordering': "['order']", 'object_name': 'Newsletter'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'confirm_message': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'languages': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'requires_double_optin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'vendor_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'welcome': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'})
+        },
+        'news.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'primary_key': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'default': "'f02e8016-94e3-49be-8cd0-8dfa0d0fb5f9'", 'max_length': '40', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['news']

--- a/news/models.py
+++ b/news/models.py
@@ -130,3 +130,23 @@ def post_newsletter_delete(sender, **kwargs):
     # Cannot import earlier due to circular import
     from news.newsletters import clear_newsletter_cache
     clear_newsletter_cache()
+
+
+class APIUser(models.Model):
+    """On some API calls, an API key must be passed that must
+    exist in this table."""
+    name = models.CharField(
+        max_length=256,
+        help_text="Descriptive name of this user"
+    )
+    api_key = models.CharField(max_length=40,
+                               default=lambda: str(uuid4()),
+                               db_index=True)
+    enabled = models.BooleanField(default=True)
+
+    class Meta:
+        verbose_name = "API User"
+
+    @classmethod
+    def is_valid(cls, api_key):
+        return cls.objects.filter(api_key=api_key, enabled=True).exists()

--- a/news/tests/test_users.py
+++ b/news/tests/test_users.py
@@ -1,13 +1,14 @@
 import json
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from django.test import TestCase
 
 from mock import patch, ANY
 
 from news import models, tasks
 from news.backends.common import NewsletterException
-from news.models import Newsletter
+from news.models import Newsletter, APIUser
 from news.views import look_for_user, get_user_data
 
 
@@ -280,3 +281,112 @@ class UserTest(TestCase):
             'status': 'error',
             'desc': 'DANGER!',
         })
+
+
+class TestLookupUser(TestCase):
+    """test for API lookup-user"""
+    # Keep in mind that this API requires SSL. We make it look like an
+    # SSL request by adding {'wsgi.url_scheme': 'https'} to the arguments
+    # of the client.get
+
+    def setUp(self):
+        self.auth = APIUser.objects.create(name="test")
+        self.user_data = {'status': 'ok'}
+        self.url = reverse('lookup_user')
+
+    def ssl_get(self, params=None, **extra):
+        extra['wsgi.url_scheme'] = 'https'
+        params = params or {}
+        return self.client.get(self.url, data=params, **extra)
+
+    def test_no_parms(self):
+        """Passing no parms is a 400 error"""
+        rsp = self.ssl_get()
+        self.assertEqual(400, rsp.status_code, rsp.content)
+
+    def test_both_parms(self):
+        """Passing both parms is a 400 error"""
+        params = {
+            'token': 'dummy',
+            'email': 'dummy@example.com',
+        }
+        rsp = self.ssl_get(params=params)
+        self.assertEqual(400, rsp.status_code, rsp.content)
+
+    def test_not_ssl(self):
+        """Without SSL, immediate 401"""
+        rsp = self.client.get(self.url)
+        self.assertEqual(401, rsp.status_code, rsp.content)
+
+    @patch('news.views.get_user_data')
+    def test_with_token(self, get_user_data):
+        """Passing a token gets back that user's data"""
+        get_user_data.return_value = self.user_data
+        params = {
+            'token': 'dummy',
+        }
+        rsp = self.ssl_get(params=params)
+        self.assertEqual(200, rsp.status_code, rsp.content)
+        self.assertEqual(self.user_data, json.loads(rsp.content))
+
+    def test_with_email_no_api_key(self):
+        """Passing email without api key is a 401"""
+        params = {
+            'email': 'mail@example.com',
+        }
+        rsp = self.ssl_get(params)
+        self.assertEqual(401, rsp.status_code, rsp.content)
+
+    def test_with_email_disabled_auth(self):
+        """Passing email with a disabled api key is a 401"""
+        self.auth.enabled = False
+        self.auth.save()
+        params = {
+            'email': 'mail@example.com',
+            'api-key': self.auth.api_key,
+        }
+        rsp = self.ssl_get(params)
+        self.assertEqual(401, rsp.status_code, rsp.content)
+
+    def test_with_email_bad_auth(self):
+        """Passing email with bad api key is a 401"""
+        params = {
+            'email': 'mail@example.com',
+            'api-key': 'BAD KEY',
+        }
+        rsp = self.ssl_get(params)
+        self.assertEqual(401, rsp.status_code, rsp.content)
+
+    @patch('news.views.get_user_data')
+    def test_with_email_and_auth_parm(self, get_user_data):
+        """Passing email and valid api key parm gets user's data"""
+        params = {
+            'email': 'mail@example.com',
+            'api-key': self.auth.api_key,
+        }
+        get_user_data.return_value = self.user_data
+        rsp = self.ssl_get(params)
+        self.assertEqual(200, rsp.status_code, rsp.content)
+        self.assertEqual(self.user_data, json.loads(rsp.content))
+
+    @patch('news.views.get_user_data')
+    def test_with_email_and_auth_header(self, get_user_data):
+        """Passing email and valid api key header gets user's data"""
+        params = {
+            'email': 'mail@example.com',
+        }
+        get_user_data.return_value = self.user_data
+        rsp = self.ssl_get(params, HTTP_X_API_KEY=self.auth.api_key)
+        self.assertEqual(200, rsp.status_code, rsp.content)
+        self.assertEqual(self.user_data, json.loads(rsp.content))
+
+    @patch('news.views.get_user_data')
+    def test_no_user(self, get_user_data):
+        """If no such user, returns 404"""
+        get_user_data.return_value = None
+        params = {
+            'email': 'mail@example.com',
+            'api-key': self.auth.api_key,
+        }
+        rsp = self.ssl_get(params)
+        self.assertEqual(404, rsp.status_code, rsp.content)

--- a/news/urls.py
+++ b/news/urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls.defaults import patterns, url
 
-from .views import (subscribe, subscribe_sms, unsubscribe, user, confirm,
-                    debug_user, custom_unsub_reason, custom_update_phonebook,
-                    custom_update_student_ambassadors, newsletters)
+from .views import (confirm, custom_unsub_reason, custom_update_phonebook,
+                    custom_update_student_ambassadors, debug_user,
+                    lookup_user, newsletters, subscribe, subscribe_sms,
+                    unsubscribe, user)
 
 
 urlpatterns = patterns('',
@@ -12,6 +13,7 @@ urlpatterns = patterns('',
     url('^user/(.*)/$', user),
     url('^confirm/(.*)/$', confirm),
     url('^debug-user/$', debug_user),
+    url('^lookup-user/$', lookup_user, name='lookup_user'),
 
     url('^custom_unsub_reason/$', custom_unsub_reason),
     url('^custom_update_student_ambassadors/(.*)/$',


### PR DESCRIPTION
- New lookup-user API
- Requires SSL
- Can look up by token or by email.
- Looking up by email requires a shared secret "auth key" to
  be included.
- Doc added to apps/news/README
- Tests added

Notes:
- This just adds a new API and does not change the behavior of any
  existing APIs, so should be safe to deploy without breaking anybody.
- If production basket is behind a proxy or load balancer, the check
  for SSL might not work right without some settings changes (see
  https://docs.djangoproject.com/en/1.5/ref/settings/#std:setting-SECURE_PROXY_SSL_HEADER)
