### PR TITLE
Bug 823987 - Add default confirmation message for english

### DIFF
--- a/news/admin.py
+++ b/news/admin.py
@@ -13,10 +13,12 @@ admin.site.register(Subscriber, SubscriberAdmin)
 
 
 class NewsletterAdmin(admin.ModelAdmin):
-    fields = ('title', 'slug', 'vendor_id', 'welcome', 'description',
-              'languages', 'show', 'order', 'active', 'requires_double_optin')
+    fields = ('title', 'slug', 'vendor_id', 'welcome', 'confirm_message',
+              'description', 'languages', 'show', 'order', 'active',
+              'requires_double_optin')
     list_display = ('order', 'title', 'slug', 'vendor_id', 'welcome',
-                    'languages', 'show', 'active', 'requires_double_optin')
+                    'confirm_message', 'languages', 'show', 'active',
+                    'requires_double_optin')
     list_display_links = ('title', 'slug')
     list_editable = ('order', 'show', 'active', 'requires_double_optin')
     list_filter = ('show', 'active', 'requires_double_optin')

--- a/news/tasks.py
+++ b/news/tasks.py
@@ -27,6 +27,7 @@ SET = 3
 
 # Double optin-in languages
 CONFIRM_SENDS = {
+    'en': 'en_confirmation_email',
     'es': 'es_confirmation_email',
     'es-ES': 'es_confirmation_email',
     'de': 'de_confirmation_email',

--- a/news/tests/test_send_confirm_notice.py
+++ b/news/tests/test_send_confirm_notice.py
@@ -29,8 +29,8 @@ class TestSendConfirmNotice(TestCase):
 
     def test_default_confirm_notice_H(self, send_message):
         """Test newsletter that has no explicit confirm"""
-        send_confirm_notice(self.email, self.token, "es", "H", ['slug2'])
-        expected_message = CONFIRM_SENDS["es"]
+        send_confirm_notice(self.email, self.token, "en", "H", ['slug2'])
+        expected_message = CONFIRM_SENDS["en"]
         send_message.assert_called_with(expected_message,
                                         self.email,
                                         self.token,


### PR DESCRIPTION
If a newsletter doesn't have a custom confirmation message configured,
use the default one. Had to add one for English since we never needed
one before, but now we can do double-opt-in for English too.

Also add confirmation message to admin
