### PR TITLE
Bug 901541 - Newsletter recovery email

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -245,6 +245,26 @@ The following URLs are available (assuming "/news" is app url):
             'master': True if we found them in the master subscribers table
         }
 
-    Note that because this method always calls Exact Target one or
-    more times, it can be slower than some other Basket APIs, and will
-    fail if ET is down.
+    Note: Because this method always calls Exact Target one or more times, it
+    can be slower than some other Basket APIs, and will fail if ET is down.
+
+/news/recover/
+--------------
+
+    This sends an email message to a user, containing a link they can use to
+    manage their subscriptions::
+
+        method: POST
+        fields: email
+        returns:  { status: ok } on success
+                  { status: error, desc: <desc> } on error
+
+    The email address is passed as 'email' in the POST data. If it is missing
+    or not syntactically correct, a 400 is returned. Otherwise, a message is
+    sent to the email, containing a link to the existing subscriptions page
+    with their token in it, so they can use it to manage their subscriptions.
+
+    If the user is known in ET, the message will be sent in their preferred
+    language and format.
+
+    If the email provided is not known, a 404 status is returned.

--- a/news/forms.py
+++ b/news/forms.py
@@ -1,0 +1,6 @@
+from django import forms
+
+
+class EmailForm(forms.Form):
+    """Form to validate email addresses"""
+    email = forms.EmailField()

--- a/news/tests/test_tasks.py
+++ b/news/tests/test_tasks.py
@@ -1,0 +1,71 @@
+from mock import patch
+
+from django.test import TestCase
+
+from news.models import Subscriber
+from news.tasks import RECOVERY_MESSAGE_ID, mogrify_message_id, \
+    send_recovery_message_task
+
+
+@patch('news.tasks.send_message', autospec=True)
+@patch('news.views.look_for_user', autospec=True)
+class RecoveryMessageTask(TestCase):
+    def setUp(self):
+        self.email = "dude@example.com"
+
+    def test_unknown_email(self, mock_look_for_user, mock_send):
+        """Email not in basket or ET"""
+        # Should log error and return
+        mock_look_for_user.return_value = None
+        send_recovery_message_task(self.email)
+        self.assertFalse(mock_send.called)
+
+    def test_email_only_in_et(self, mock_look_for_user, mock_send):
+        """Email not in basket but in ET"""
+        # Should create new subscriber with ET data, then trigger message
+        # We can follow the user's format and lang pref
+        format = 'T'
+        lang = 'fr'
+        mock_look_for_user.return_value = {
+            'status': 'ok',
+            'email': self.email,
+            'format': format,
+            'country': '',
+            'lang': lang,
+            'token': 'USERTOKEN',
+            'newsletters': [],
+        }
+        send_recovery_message_task(self.email)
+        subscriber = Subscriber.objects.get(email=self.email)
+        self.assertEqual('USERTOKEN', subscriber.token)
+        message_id = mogrify_message_id(RECOVERY_MESSAGE_ID, lang, format)
+        mock_send.assert_called_with(message_id, self.email,
+                                     subscriber.token, format)
+
+    def test_email_only_in_basket(self, mock_look_for_user, mock_send):
+        """Email known in basket, not in ET"""
+        # Should log error and return
+        Subscriber.objects.create(email=self.email)
+        mock_look_for_user.return_value = None
+        send_recovery_message_task(self.email)
+        self.assertFalse(mock_send.called)
+
+    def test_email_in_both(self, mock_look_for_user, mock_send):
+        """Email known in both basket and ET"""
+        # We can follow the user's format and lang pref
+        subscriber = Subscriber.objects.create(email=self.email)
+        format = 'T'
+        lang = 'fr'
+        mock_look_for_user.return_value = {
+            'status': 'ok',
+            'email': self.email,
+            'format': format,
+            'country': '',
+            'lang': lang,
+            'token': subscriber.token,
+            'newsletters': [],
+        }
+        send_recovery_message_task(self.email)
+        message_id = mogrify_message_id(RECOVERY_MESSAGE_ID, lang, format)
+        mock_send.assert_called_with(message_id, self.email,
+                                     subscriber.token, format)

--- a/news/urls.py
+++ b/news/urls.py
@@ -2,8 +2,9 @@ from django.conf.urls import patterns, url
 
 from .views import (confirm, custom_unsub_reason, custom_update_phonebook,
                     custom_update_student_ambassadors, debug_user,
-                    list_newsletters, lookup_user, newsletters, subscribe,
-                    subscribe_sms, unsubscribe, user)
+                    list_newsletters, lookup_user, newsletters,
+                    send_recovery_message, subscribe, subscribe_sms,
+                    unsubscribe, user)
 
 
 urlpatterns = patterns('',
@@ -14,6 +15,7 @@ urlpatterns = patterns('',
     url('^confirm/(.*)/$', confirm),
     url('^debug-user/$', debug_user),
     url('^lookup-user/$', lookup_user, name='lookup_user'),
+    url('^recover/$', send_recovery_message, name='send_recovery_message'),
 
     url('^custom_unsub_reason/$', custom_unsub_reason),
     url('^custom_update_student_ambassadors/(.*)/$',


### PR DESCRIPTION
Add API that given an email address, sends an email to that address
with a link to allow that user to manage their subscriptions.

(I'm not sure if the message needed for this has been created in ET yet, but it doesn't matter as long as nobody starts using this API yet.)
