### PR TITLE
Delete records from Exact Target

### DIFF
--- a/news/backends/et-wsdl.txt
+++ b/news/backends/et-wsdl.txt
@@ -2905,6 +2905,14 @@
         <complexContent>
           <extension base="tns:ObjectExtension">
             <sequence>
+              <element name="Name" minOccurs="0" maxOccurs="1" type="xsd:string" />
+              <element name="Keys" minOccurs="0" maxOccurs="1">
+                <complexType>
+                  <sequence>
+                    <element name="Key" minOccurs="0" maxOccurs="unbounded" type="tns:APIProperty" />
+                  </sequence>
+                </complexType>
+              </element>
             </sequence>
           </extension>
         </complexContent>


### PR DESCRIPTION
- Add a method to delete a subscriber's record from one of our Exact
  Target data extensions, given the token.
- Manually tested with my own data extensions, verified that it deletes
  the desired record and no others.

This adds the method, but does not use it yet.

This will probably be needed for changing user email addresses.
