### PR TITLE
Bug 853990 Fix suds cache usage

### DIFF
--- a/news/backends/exacttarget.py
+++ b/news/backends/exacttarget.py
@@ -22,6 +22,7 @@ from functools import wraps
 from django.core.cache import cache
 
 from suds import WebFault
+from suds.cache import Cache
 from suds.client import Client
 from suds.wsse import Security, UsernameToken
 
@@ -38,7 +39,7 @@ from .common import NewsletterException, NewsletterNoResultsException, \
 WSDL_URL = 'file://%s/et-wsdl.txt' % os.path.dirname(os.path.abspath(__file__))
 
 
-class SudsDjangoCache(object):
+class SudsDjangoCache(Cache):
     """
     Implement the suds cache interface using Django caching.
     """


### PR DESCRIPTION
We made a change to use our own cache with Suds, but it turns out that
Suds uses named type checking to validate the cache instead of duck
typing, so we need to inherit from Suds's cache even though we don't
use anything from it.
