### PR TITLE
Bug 875369 - Log failed Basket tasks

### DIFF
--- a/news/admin.py
+++ b/news/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import APIUser, Newsletter, Subscriber
+from .models import APIUser, FailedTask, Newsletter, Subscriber
 
 
 class APIUserAdmin(admin.ModelAdmin):
@@ -34,3 +34,10 @@ class NewsletterAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Newsletter, NewsletterAdmin)
+
+
+class FailedTaskAdmin(admin.ModelAdmin):
+    list_display = ('when', '__unicode__')
+
+
+admin.site.register(FailedTask, FailedTaskAdmin)

--- a/news/migrations/0007_auto__add_failedtask.py
+++ b/news/migrations/0007_auto__add_failedtask.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'FailedTask'
+        db.create_table(u'news_failedtask', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('when', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+            ('task_id', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('args', self.gf('jsonfield.fields.JSONField')(default=[])),
+            ('kwargs', self.gf('jsonfield.fields.JSONField')(default={})),
+            ('exc', self.gf('django.db.models.fields.TextField')(default=None, null=True)),
+            ('einfo', self.gf('django.db.models.fields.TextField')(default=None, null=True)),
+        ))
+        db.send_create_signal(u'news', ['FailedTask'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'FailedTask'
+        db.delete_table(u'news_failedtask')
+
+
+    models = {
+        u'news.apiuser': {
+            'Meta': {'object_name': 'APIUser'},
+            'api_key': ('django.db.models.fields.CharField', [], {'default': "'ba3fde79-fba3-445f-a65f-5649da6f5cec'", 'max_length': '40', 'db_index': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        u'news.failedtask': {
+            'Meta': {'object_name': 'FailedTask'},
+            'args': ('jsonfield.fields.JSONField', [], {'default': '[]'}),
+            'einfo': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True'}),
+            'exc': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'kwargs': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'task_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'when': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'news.newsletter': {
+            'Meta': {'ordering': "['order']", 'object_name': 'Newsletter'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'confirm_message': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'languages': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'requires_double_optin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'vendor_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'welcome': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'})
+        },
+        u'news.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'primary_key': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'default': "'704868b0-9986-4bb4-acdb-849651f7cc66'", 'max_length': '40', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['news']

--- a/news/urls.py
+++ b/news/urls.py
@@ -7,7 +7,7 @@ from .views import (confirm, custom_unsub_reason, custom_update_phonebook,
                     unsubscribe, user)
 
 
-urlpatterns = patterns('',
+urlpatterns = patterns('',  # noqa
     url('^subscribe/$', subscribe),
     url('^subscribe_sms/$', subscribe_sms),
     url('^unsubscribe/(.*)/$', unsubscribe),

--- a/settings/base.py
+++ b/settings/base.py
@@ -35,6 +35,7 @@ ALLOWED_HOSTS = [
 ]
 
 TIME_ZONE = 'America/Los_Angeles'
+USE_TZ = True
 SITE_ID = 1
 USE_I18N = False
 


### PR DESCRIPTION
When a basket task is unable to complete (after exhausting its allowed
retries), log the task name, parameters, and whatever exception made
it fail into a database table where we can look at it later.
