### PR TITLE
Bug 907330 - confirm notice handle short form of language

### DIFF
--- a/news/newsletters.py
+++ b/news/newsletters.py
@@ -99,5 +99,13 @@ def newsletter_languages():
     return lang_set
 
 
+def is_supported_newsletter_language(code):
+    """
+    Return True if the given language code is supported by any of the
+    newsletters. (Only compares first two chars; case-insensitive.)
+    """
+    return code[:2].lower() in [lang[:2].lower() for lang in newsletter_languages()]
+
+
 def clear_newsletter_cache():
     cache.delete(CACHE_KEY)

--- a/news/tasks.py
+++ b/news/tasks.py
@@ -15,7 +15,8 @@ from celery.task import Task, task
 from .backends.common import NewsletterException
 from .backends.exacttarget import (ExactTarget, ExactTargetDataExt)
 from .models import FailedTask, Newsletter
-from .newsletters import newsletter_field, newsletter_languages, newsletter_slugs
+from .newsletters import (is_supported_newsletter_language, newsletter_field,
+                          newsletter_slugs)
 
 
 log = logging.getLogger(__name__)
@@ -489,15 +490,11 @@ def send_confirm_notice(email, token, lang, format, newsletter_slugs):
         lang = 'en'   # If we don't know a language, use English
 
     # Is the language supported?
-    supported_languages = newsletter_languages()
-    if lang not in supported_languages:
-        if lang[:2] in supported_languages:
-            lang = lang[:2]
-        else:
-            msg = "Cannot send confirmation message in language '%s' " \
-                  "that is not a supported newsletter language" % lang
-            log.error(msg)
-            raise BasketError(msg)
+    if not is_supported_newsletter_language(lang):
+        msg = "Cannot send confirmation message in language '%s' " \
+              "that is not a supported newsletter language" % lang
+        log.error(msg)
+        raise BasketError(msg)
 
     # See if any newsletters have a custom confirmation message
     # We only need to find one; if so, we'll use the first we find.

--- a/news/tests/test_send_confirm_notice.py
+++ b/news/tests/test_send_confirm_notice.py
@@ -17,7 +17,7 @@ class TestSendConfirmNotice(TestCase):
             slug='slug1',
             vendor_id='VENDOR1',
             confirm_message='confirm1',
-            languages='en,es'
+            languages='en,es,rr-QQ'   # rr is a made-up language
         )
         self.newsletter2 = Newsletter.objects.create(
             slug='slug2',
@@ -44,6 +44,15 @@ class TestSendConfirmNotice(TestCase):
                                         self.email,
                                         self.token,
                                         'T')
+
+    def test_default_confirm_notice_short_for_long(self, send_message):
+        """Test using short form of lang that's in the newsletter list as a long lang"""
+        send_confirm_notice(self.email, self.token, "rr", "H", ['slug2'])
+        expected_message = mogrify_message_id(CONFIRMATION_MESSAGE, 'rr', 'H')
+        send_message.assert_called_with(expected_message,
+                                        self.email,
+                                        self.token,
+                                        'H')
 
     ### known long lang
 


### PR DESCRIPTION
If user has selected 'pt', and our newsletters only list 'pt-BR' as a
supported language, that should work.
