### PR TITLE
Bug 962225: Fix issue with unescaped characters in emails.

### DIFF
--- a/news/tests/test_views.py
+++ b/news/tests/test_views.py
@@ -32,12 +32,10 @@ class FxOSMalformedPOSTTest(TestCase):
                               content_type='text/plain; charset=UTF-8')
         self.assertFalse(bool(req.POST))
         views.subscribe(req)
-        update_user_mock.assert_called_with(req, views.SUBSCRIBE, data=ANY, optin=True, sync=False)
-        data = update_user_mock.call_args[1]['data']
-        self.assertDictEqual(data.dict(), {
+        update_user_mock.assert_called_with(req, views.SUBSCRIBE, data={
             'email': 'dude@example.com',
             'newsletters': 'firefox-os',
-        })
+        }, optin=True, sync=False)
 
 
 class SubscribeTest(TestCase):

--- a/news/views.py
+++ b/news/views.py
@@ -3,7 +3,7 @@ import json
 import re
 
 from django.conf import settings
-from django.http import HttpResponse, QueryDict
+from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.decorators.cache import cache_control, never_cache
 from django.views.decorators.csrf import csrf_exempt
@@ -406,7 +406,9 @@ def subscribe(request):
         raw_request = request.read()
         if 'newsletters=' in raw_request:
             # malformed request from FxOS
-            data = QueryDict(raw_request, encoding=request.encoding)
+            # Can't use QueryDict since the string is not url-encoded.
+            # It will convert '+' to ' ' for example.
+            data = dict(pair.split('=') for pair in raw_request.split('&'))
         else:
             return HttpResponseJSON({
                 'status': 'error',


### PR DESCRIPTION
The string from FxOS is _NOT_ urlencoded, therefore common email symbols like
"+" are not escaped. This will cause them to be converted to " " by QueryDict.
Fix this by doing a much more simple parse of the string.

@jgmize r?
