### PR TITLE
Bug 912055: Fix issue with email address suggestion

### DIFF
--- a/news/email.py
+++ b/news/email.py
@@ -20,5 +20,10 @@ def get_valid_email(email):
     if email != good_email:
         log.info('Using suggested alternate email')
         suggestion = True
+
+    good_email = address.validate_address(good_email)
+    if isinstance(good_email, address.EmailAddress):
+        good_email = good_email.address
+
     # returns None if the email is invalid, or the email if all's well
-    return address.validate_address(good_email), suggestion
+    return good_email, suggestion

--- a/news/tests/test_email.py
+++ b/news/tests/test_email.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from flanker.addresslib.address import EmailAddress
 from mock import patch
 from nose.tools import ok_, eq_
 
@@ -30,9 +31,11 @@ class TestGetValidEmail(TestCase):
         """Should correct a misspelled domain and pass it back."""
         email2 = 'dude2@example.com'
         mock_suggest.return_value = email2
-        mock_validate.return_value = email2
+        mock_validate.return_value = EmailAddress('', email2)
         result, is_suggestion = get_valid_email(self.email)
         ok_(is_suggestion)
+        # should return a string, not the EmailAddress instance
+        ok_(isinstance(result, basestring))
         eq_(result, email2)
 
     def test_invalid_email(self, mock_validate, mock_suggest):

--- a/news/views.py
+++ b/news/views.py
@@ -454,12 +454,16 @@ def invalid_email_response(e):
 
 
 def validate_email(data):
-    """Validates that the email in the data arg is valid.
+    """Validates that the email key in the passed dict is valid.
 
     Alternately checks that the 'validated' arg was passed in.
     Returns None on success and raises a ValidationError if
     invalid. The exception will have a 'suggestion' parameter
     that will contain the suggested email address or None.
+
+    @param data: dict. usually the POST data
+    @return: None if email address in the 'email' key is valid
+    @raise: EmailValidationError if 'email' key is invalid
     """
     # we send suggestions back to users of valid email addresses.
     # A client could choose to use that suggestion or indicate that


### PR DESCRIPTION
The validation function from flanker actually returns instances of a custom
EmailAddress class, and basket expected a string. This caused 500s when the
JSON serializer couldn't work with the custom class.

@jgmize r?
