### PR TITLE
Fix bug 1011001: Add support for optin param back to subscribe.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.6"
 before_script:
-  - flake8 --exclude=migrations --ignore=E121,E123,E124,E125,E126,E127,E128,E501 news
+  - flake8 news
   - mysql -e 'create database basket;'
   - python manage.py syncdb --noinput --migrate
 script: coverage run manage.py test news

--- a/README.rst
+++ b/README.rst
@@ -118,9 +118,7 @@ The following URLs are available (assuming "/news" is app url):
 
     This method subscribes the user to the newsletters defined in the
     "newsletters" field, which should be a comma-delimited list of
-    newsletters. "email" and "newsletters" are required. "optin" should
-    be Y or N depending if the user should automatically be opted in,
-    default is Y. "trigger_welcome" should be Y to fire off a welcome email::
+    newsletters. "email" and "newsletters" are required::
 
         method: POST
         fields: email, format, country, lang, newsletters, optin, source_url, trigger_welcome, sync
@@ -131,11 +129,23 @@ The following URLs are available (assuming "/news" is app url):
 
     ``format`` can be any of the following values: H, html, T, or text
 
+    ``country`` is the 2 letter country code for the subscriber.
+
+    ``lang`` is the language code for the subscriber (e.g. de, pt-BR)
+
+    ``optin`` should be set to "Y" if the user should not go through the
+    double-optin process (email verification). Setting this option requires
+    an API key and the use of SSL. Defaults to "N".
+
+    ``trigger_welcome`` should be set to "N" if you do not want welcome emails
+    to be sent once the user successfully subscribes and verifies their email.
+    Defaults to "Y".
+
     ``sync`` is an optional field. If set to Y, basket will ensure the response
     includes the token for the provided email address, creating one if necessary.
     If you don't need the token, or don't need it immediately, leave off ``sync``
     so Basket has the option to optimize by doing the entire subscribe in the
-    background after returning from this call.
+    background after returning from this call. Defaults to "N".
 
     Using ``sync=Y`` requires SSL and an API key.
 

--- a/news/newsletters.py
+++ b/news/newsletters.py
@@ -10,7 +10,7 @@ from news.models import Newsletter
 
 
 __all__ = ('clear_newsletter_cache', 'newsletter_field', 'newsletter_name',
-           'newsletter_fields', 'newsletter_names')
+           'newsletter_fields')
 
 
 CACHE_KEY = "newsletters_cache_data"

--- a/news/tasks.py
+++ b/news/tasks.py
@@ -296,8 +296,9 @@ def update_user(data, email, token, created, type, optin):
     :param boolean created: Whether a new user was created in Basket
     :param int type: What kind of API call it was. Could be
         SUBSCRIBE, UNSUBSCRIBE, or SET.
-    :param boolean optin: whether the POST had an OPTIN parameter
-        with value "Y".  (Unused)
+    :param boolean optin: Whether the user should go through the
+        double-optin process or not. If ``optin`` is ``True`` then
+        the user should bypass the double-optin process.
 
     :returns: One of the return codes UU_ALREADY_CONFIRMED,
         etc. (see code) to indicate what case we figured out we were
@@ -387,7 +388,7 @@ def update_user(data, email, token, created, type, optin):
     # When including any newsletter that does not
     # require confirmation, user gets a pass on confirming and goes straight
     # to confirmed.
-    exempt_from_confirmation = Newsletter.objects\
+    exempt_from_confirmation = optin or Newsletter.objects\
         .filter(slug__in=to_subscribe, requires_double_optin=False)\
         .exists()
 

--- a/news/tests/test_confirm.py
+++ b/news/tests/test_confirm.py
@@ -18,8 +18,7 @@ class TestConfirmationLogic(TestCase):
                            user_in_optin, user_in_confirmed,
                            newsletter_with_required_confirmation,
                            newsletter_without_required_confirmation,
-                           is_english, type,
-                           expected_result):
+                           is_english, type, expected_result, is_optin=False):
         # Generic test routine - given a bunch of initial conditions and
         # an expected result, set up the conditions, make the call,
         # and verify we get the expected result.
@@ -84,7 +83,7 @@ class TestConfirmationLogic(TestCase):
                     with patch('news.tasks.send_confirm_notice'):
                         created = not user_in_basket
                         rc = update_user(data, email, token, created, type,
-                                         True)
+                                         is_optin)
         self.assertEqual(expected_result, rc)
 
     #
@@ -146,6 +145,18 @@ class TestConfirmationLogic(TestCase):
                                 type=SUBSCRIBE,
                                 expected_result=UU_MUST_CONFIRM_NEW)
 
+    def test_new_english_optin(self):
+        self.check_confirmation(user_in_basket=False,
+                                user_in_master=False,
+                                user_in_optin=False,
+                                user_in_confirmed=False,
+                                newsletter_with_required_confirmation=True,
+                                newsletter_without_required_confirmation=False,
+                                is_english=True,
+                                is_optin=True,
+                                type=SUBSCRIBE,
+                                expected_result=UU_EXEMPT_NEW)
+
     #
     # Tests for users already pending confirmation
     #
@@ -195,6 +206,18 @@ class TestConfirmationLogic(TestCase):
                                 newsletter_with_required_confirmation=True,
                                 newsletter_without_required_confirmation=True,
                                 is_english=False,
+                                type=SUBSCRIBE,
+                                expected_result=UU_EXEMPT_PENDING)
+
+    def test_pending_english_optin(self):
+        self.check_confirmation(user_in_basket=False,
+                                user_in_master=False,
+                                user_in_optin=True,
+                                user_in_confirmed=False,
+                                newsletter_with_required_confirmation=True,
+                                newsletter_without_required_confirmation=False,
+                                is_english=True,
+                                is_optin=True,
                                 type=SUBSCRIBE,
                                 expected_result=UU_EXEMPT_PENDING)
 

--- a/news/views.py
+++ b/news/views.py
@@ -416,8 +416,13 @@ def subscribe(request):
                 'code': errors.BASKET_USAGE_ERROR,
             }, 400)
 
-    optin = data.get('optin', 'Y') == 'Y'
-    sync = data.get('sync', 'N') == 'Y'
+    optin = data.get('optin', 'N').upper() == 'Y'
+    sync = data.get('sync', 'N').upper() == 'Y'
+
+    if optin and (not request.is_secure() or not has_valid_api_key(request)):
+        # for backward compat we just ignore the optin if
+        # no valid API key is sent.
+        optin = False
 
     if sync:
         if not request.is_secure():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+ignore=E121,E123,E124,E125,E126,E127,E128,E501
+exclude=migrations


### PR DESCRIPTION
Setting optin=Y will now require an API key and SSL to avoid people
being signed up without a confirmation step.
