### PR TITLE
Remove FxOS workaround now that bug 962225 is fixed.

### DIFF
--- a/news/tests/test_views.py
+++ b/news/tests/test_views.py
@@ -174,32 +174,6 @@ class GetBestLanguageTests(TestCase):
         self._test([], None)
 
 
-@patch('news.views.validate_email', none_mock)
-@patch('news.views.update_user_task')
-class FxOSMalformedPOSTTest(TestCase):
-    """Bug 962225"""
-
-    def setUp(self):
-        self.rf = RequestFactory()
-
-    def test_deals_with_broken_post_data(self, update_user_mock):
-        """Should be able to parse data from the raw request body.
-
-        FxOS sends POST requests with the wrong mime-type, so request.POST is never
-        filled out. We should parse the raw request body to get the data until this
-        is fixed in FxOS in bug 949170.
-        """
-        req = self.rf.generic('POST', '/news/subscribe/',
-                              data='email=dude+abides@example.com&newsletters=firefox-os',
-                              content_type='text/plain; charset=UTF-8')
-        self.assertFalse(bool(req.POST))
-        views.subscribe(req)
-        update_user_mock.assert_called_with(req, views.SUBSCRIBE, data={
-            'email': 'dude+abides@example.com',
-            'newsletters': 'firefox-os',
-        }, optin=False, sync=False)
-
-
 class SubscribeEmailValidationTest(TestCase):
     email = 'dude@example.com'
     data = {

--- a/news/views.py
+++ b/news/views.py
@@ -504,20 +504,11 @@ def subscribe(request):
     data = request.POST.dict()
     newsletters = data.get('newsletters', None)
     if not newsletters:
-        # request.body causes tests to raise exceptions
-        # while request.read() works.
-        raw_request = request.read()
-        if 'newsletters=' in raw_request:
-            # malformed request from FxOS
-            # Can't use QueryDict since the string is not url-encoded.
-            # It will convert '+' to ' ' for example.
-            data = dict(pair.split('=') for pair in raw_request.split('&'))
-        else:
-            return HttpResponseJSON({
-                'status': 'error',
-                'desc': 'newsletters is missing',
-                'code': errors.BASKET_USAGE_ERROR,
-            }, 400)
+        return HttpResponseJSON({
+            'status': 'error',
+            'desc': 'newsletters is missing',
+            'code': errors.BASKET_USAGE_ERROR,
+        }, 400)
 
     optin = data.get('optin', 'N').upper() == 'Y'
     sync = data.get('sync', 'N').upper() == 'Y'


### PR DESCRIPTION
Was reading through `subscribe` and noticed that [bug 962225](https://bugzilla.mozilla.org/show_bug.cgi?id=962225) is fixed now, so this workaround code can go away, yeah?