### PR TITLE
Async subscribe

### DIFF
--- a/news/tests/test__utils.py
+++ b/news/tests/test__utils.py
@@ -1,0 +1,266 @@
+import json
+
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from basket import errors
+from mock import Mock, patch
+
+from news import tasks
+from news.tasks import SUBSCRIBE
+from news.utils import (
+    get_accept_languages,
+    get_best_language,
+    language_code_is_valid,
+    update_user_task
+)
+
+
+class UpdateUserTaskTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+        patcher = patch('news.utils.lookup_subscriber')
+        self.lookup_subscriber = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch.object(tasks, 'update_user')
+        self.update_user = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def assert_response_error(self, response, status_code, basket_code):
+        self.assertEqual(response.status_code, status_code)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data['code'], basket_code)
+
+    def assert_response_ok(self, response, **kwargs):
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data['status'], 'ok')
+
+        del response_data['status']
+        self.assertEqual(response_data, kwargs)
+
+    def test_invalid_newsletter(self):
+        """If an invalid newsletter is given, return a 400 error."""
+        request = self.factory.post('/')
+
+        with patch('news.utils.newsletter_slugs') as newsletter_slugs:
+            newsletter_slugs.return_value = ['foo', 'baz']
+            response = update_user_task(request, SUBSCRIBE, {'newsletters': 'foo,bar'})
+
+            self.assert_response_error(response, 400, errors.BASKET_INVALID_NEWSLETTER)
+
+    def test_invalid_lang(self):
+        """If the given lang is invalid, return a 400 error."""
+        request = self.factory.post('/')
+
+        with patch('news.utils.language_code_is_valid') as mock_language_code_is_valid:
+            mock_language_code_is_valid.return_value = False
+            response = update_user_task(request, SUBSCRIBE, {'lang': 'pt-BR'})
+
+            self.assert_response_error(response, 400, errors.BASKET_INVALID_LANGUAGE)
+            mock_language_code_is_valid.assert_called_with('pt-BR')
+
+    def test_missing_email_and_sub(self):
+        """
+        If both the email and subscriber are missing, return a 400
+        error.
+        """
+        request = self.factory.post('/')
+        response = update_user_task(request, SUBSCRIBE)
+
+        self.assert_response_error(response, 400, errors.BASKET_USAGE_ERROR)
+
+    def test_success_no_sync(self):
+        """
+        If sync is False, do not generate a token via lookup_subscriber
+        and return an OK response without a token.
+        """
+        request = self.factory.post('/')
+        data = {'email': 'a@example.com'}
+
+        response = update_user_task(request, SUBSCRIBE, data, sync=False)
+        self.assert_response_ok(response)
+        self.update_user.delay.assert_called_with(data, 'a@example.com', None, SUBSCRIBE, True)
+        self.assertFalse(self.lookup_subscriber.called)
+
+    def test_success_with_valid_newsletters(self):
+        """
+        If the specified newsletters are valid, return an OK response.
+        """
+        request = self.factory.post('/')
+        data = {'email': 'a@example.com', 'newsletters': 'foo,bar'}
+
+        with patch('news.utils.newsletter_slugs') as newsletter_slugs:
+            newsletter_slugs.return_value = ['foo', 'bar']
+            response = update_user_task(request, SUBSCRIBE, data, sync=False)
+            self.assert_response_ok(response)
+
+    def test_success_with_valid_lang(self):
+        """If the specified language is valid, return an OK response."""
+        request = self.factory.post('/')
+        data = {'email': 'a@example.com', 'lang': 'pt-BR'}
+
+        with patch('news.utils.language_code_is_valid') as mock_language_code_is_valid:
+            mock_language_code_is_valid.return_value = True
+            response = update_user_task(request, SUBSCRIBE, data, sync=False)
+            self.assert_response_ok(response)
+
+    def test_success_with_subscriber(self):
+        """
+        If no email is given but a subscriber is, use the subscriber's
+        email.
+        """
+        request = self.factory.post('/')
+        request.subscriber = Mock(email='a@example.com')
+        response = update_user_task(request, SUBSCRIBE, {}, sync=False)
+
+        self.assert_response_ok(response)
+        self.update_user.delay.assert_called_with({}, 'a@example.com', None, SUBSCRIBE, True)
+
+    def test_success_with_request_data(self):
+        """
+        If no data is provided, fall back to using the POST data from
+        the request.
+        """
+        data = {'email': 'a@example.com'}
+        request = self.factory.post('/', data)
+        response = update_user_task(request, SUBSCRIBE, sync=False)
+
+        self.assert_response_ok(response)
+        self.update_user.delay.assert_called_with(data, 'a@example.com', None, SUBSCRIBE, True)
+
+    def test_success_with_sync_and_subscriber(self):
+        """
+        If sync is True, and a subscriber is provided, do not call
+        lookup_subscriber and return an OK response with the token and
+        created == False.
+        """
+        request = self.factory.post('/')
+        request.subscriber = Mock(email='a@example.com', token='mytoken')
+        response = update_user_task(request, SUBSCRIBE, {}, sync=True)
+
+        self.assert_response_ok(response, token='mytoken', created=False)
+        self.update_user.delay.assert_called_with({}, 'a@example.com', 'mytoken', SUBSCRIBE, True)
+
+    def test_success_with_sync_no_subscriber(self):
+        """
+        If sync is True, and a subscriber is not provided, look them up
+        with lookup_subscriber and return an OK response with the token
+        and created from the fetched subscriber.
+        """
+        request = self.factory.post('/')
+        data = {'email': 'a@example.com'}
+        subscriber = Mock(email='a@example.com', token='mytoken')
+        self.lookup_subscriber.return_value = subscriber, None, True
+
+        response = update_user_task(request, SUBSCRIBE, data, sync=True)
+
+        self.assert_response_ok(response, token='mytoken', created=True)
+        self.update_user.delay.assert_called_with(data, 'a@example.com', 'mytoken', SUBSCRIBE, True)
+
+
+class TestGetAcceptLanguages(TestCase):
+    # mostly stolen from bedrock
+
+    def setUp(self):
+        patcher = patch('news.utils.newsletter_languages', return_value=[
+            'de', 'en', 'es', 'fr', 'id', 'pt-BR', 'ru', 'pl', 'hu'])
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def _test(self, accept_lang, good_list):
+        self.assertListEqual(get_accept_languages(accept_lang), good_list)
+
+    def test_valid_lang_codes(self):
+        """
+        Should return a list of valid lang codes
+        """
+        self._test('fr-FR', ['fr'])
+        self._test('en-us,en;q=0.5', ['en'])
+        self._test('pt-pt,fr;q=0.8,it-it;q=0.5,de;q=0.3',
+                   ['pt-PT', 'fr', 'it-IT', 'de'])
+        self._test('ja-JP-mac,ja-JP;q=0.7,ja;q=0.3', ['ja-JP', 'ja'])
+        self._test('foo,bar;q=0.5', ['foo', 'bar'])
+
+    def test_invalid_lang_codes(self):
+        """
+        Should return a list of valid lang codes or an empty list
+        """
+        self._test('', [])
+        self._test('en_us,en*;q=0.5', [])
+        self._test('Chinese,zh-cn;q=0.5', ['zh-CN'])
+
+
+class GetBestLanguageTests(TestCase):
+    def setUp(self):
+        patcher = patch('news.utils.newsletter_languages', return_value=[
+            'de', 'en', 'es', 'fr', 'id', 'pt-BR', 'ru', 'pl', 'hu'])
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def _test(self, langs_list, expected_lang):
+        self.assertEqual(get_best_language(langs_list), expected_lang)
+
+    def test_returns_first_good_lang(self):
+        """Should return first language in the list that a newsletter supports."""
+        self._test(['zh-TW', 'es', 'de', 'en'], 'es')
+        self._test(['pt-PT', 'zh-TW', 'pt-BR', 'en'], 'pt-BR')
+
+    def test_returns_first_lang_no_good(self):
+        """Should return the first in the list if no supported are found."""
+        self._test(['pt-PT', 'zh-TW', 'zh-CN', 'ar'], 'pt-PT')
+
+    def test_no_langs(self):
+        """Should return none if no langs given."""
+        self._test([], None)
+
+
+class TestLanguageCodeIsValid(TestCase):
+    def test_empty_string(self):
+        """Empty string is accepted as a language code"""
+        self.assertTrue(language_code_is_valid(''))
+
+    def test_none(self):
+        """None is a TypeError"""
+        with self.assertRaises(TypeError):
+            language_code_is_valid(None)
+
+    def test_zero(self):
+        """0 is a TypeError"""
+        with self.assertRaises(TypeError):
+            language_code_is_valid(0)
+
+    def test_exact_2_letter(self):
+        """2-letter code that's in the list is valid"""
+        self.assertTrue(language_code_is_valid('az'))
+
+    def test_exact_3_letter(self):
+        """3-letter code is valid.
+
+        There are a few of these."""
+        self.assertTrue(language_code_is_valid('azq'))
+
+    def test_exact_5_letter(self):
+        """5-letter code that's in the list is valid"""
+        self.assertTrue(language_code_is_valid('az-BY'))
+
+    def test_case_insensitive(self):
+        """Matching is not case sensitive"""
+        self.assertTrue(language_code_is_valid('az-BY'))
+        self.assertTrue(language_code_is_valid('aZ'))
+        self.assertTrue(language_code_is_valid('QW'))
+
+    def test_wrong_length(self):
+        """A code that's not a valid length is not valid."""
+        self.assertFalse(language_code_is_valid('az-'))
+        self.assertFalse(language_code_is_valid('a'))
+        self.assertFalse(language_code_is_valid('azqr'))
+        self.assertFalse(language_code_is_valid('az-BY2'))
+
+    def test_wrong_format(self):
+        """A code that's not a valid format is not valid."""
+        self.assertFalse(language_code_is_valid('a2'))
+        self.assertFalse(language_code_is_valid('asdfj'))
+        self.assertFalse(language_code_is_valid('az_BY'))

--- a/news/tests/test_confirm.py
+++ b/news/tests/test_confirm.py
@@ -74,16 +74,14 @@ class TestConfirmationLogic(TestCase):
         data['newsletters'] = ','.join(newsletters)
 
         # Mock data from ET
-        with patch('news.views.get_user_data') as get_user_data:
+        with patch('news.tasks.get_user_data') as get_user_data:
             get_user_data.return_value = user
 
             # Don't actually call ET
             with patch('news.tasks.apply_updates'):
                 with patch('news.tasks.send_welcomes'):
                     with patch('news.tasks.send_confirm_notice'):
-                        created = not user_in_basket
-                        rc = update_user(data, email, token, created, type,
-                                         is_optin)
+                        rc = update_user(data, email, token, type, is_optin)
         self.assertEqual(expected_result, rc)
 
     #

--- a/news/tests/test_tasks.py
+++ b/news/tests/test_tasks.py
@@ -1,11 +1,11 @@
+from django.test import TestCase
+
 import celery
 from mock import Mock, patch
 
-from django.test import TestCase
-
 from news.models import FailedTask, Subscriber
 from news.tasks import (RECOVERY_MESSAGE_ID, mogrify_message_id,
-    send_recovery_message_task, update_phonebook)
+    send_recovery_message_task, SUBSCRIBE, update_phonebook, update_user)
 
 
 class FailedTaskTest(TestCase):
@@ -116,3 +116,31 @@ class RecoveryMessageTask(TestCase):
         message_id = mogrify_message_id(RECOVERY_MESSAGE_ID, lang, format)
         mock_send.assert_called_with(message_id, self.email,
                                      subscriber.token, format)
+
+
+class UpdateUserTests(TestCase):
+    def _patch_tasks(self, attr, **kwargs):
+        patcher = patch('news.tasks.' + attr, **kwargs)
+        setattr(self, attr, patcher.start())
+        self.addCleanup(patcher.stop)
+
+    def setUp(self):
+        self._patch_tasks('lookup_subscriber')
+        self._patch_tasks('get_user_data')
+        self._patch_tasks('parse_newsletters', return_value=([], []))
+        self._patch_tasks('apply_updates')
+        self._patch_tasks('confirm_user')
+        self._patch_tasks('send_welcomes')
+        self._patch_tasks('send_confirm_notice')
+
+    def self_test_success_no_token_create_user(self):
+        """
+        If no token is provided, use lookup_subscriber to find (and
+        possibly create) a user with a matching email.
+        """
+        subscriber = Mock(email='a@example.com', token='mytoken')
+        self.lookup_subscriber.return_value = subscriber, None, False
+        self.get_user_data.return_value = None
+
+        update_user({}, 'a@example.com', None, SUBSCRIBE, True)
+        self.get_user_data.assert_called_with(token='mytoken')

--- a/news/tests/test_update_user.py
+++ b/news/tests/test_update_user.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 
 from django.conf import settings
 from django.test import TestCase
@@ -8,11 +7,10 @@ from django.utils.unittest import skip
 
 from mock import patch, ANY
 
-from news import models, views, tasks
+from news import models
 from news.backends.common import NewsletterException
-from news.tasks import update_user, SUBSCRIBE, UU_EXEMPT_NEW, \
-    UU_ALREADY_CONFIRMED, SET, FFOS_VENDOR_ID, \
-    FFAY_VENDOR_ID, MSG_EMAIL_OR_TOKEN_REQUIRED, UNSUBSCRIBE
+from news.tasks import (update_user, SUBSCRIBE, UU_EXEMPT_NEW, UU_ALREADY_CONFIRMED, SET,
+                        FFOS_VENDOR_ID, FFAY_VENDOR_ID, UNSUBSCRIBE)
 
 
 class UpdateUserTest(TestCase):
@@ -42,106 +40,9 @@ class UpdateUserTest(TestCase):
             'status': 'ok',
         }
 
-    @patch('news.utils.update_user.delay')
-    def test_update_user_task_helper(self, uu_mock):
-        """
-        `update_user` should always get an email and token.
-        """
-        # Fake an incoming request which we've already looked up and
-        # found a corresponding subscriber for
-        req = self.rf.post('/testing/', {'stuff': 'whanot'})
-        req.subscriber = self.sub
-        # Call update_user to subscribe
-        resp = views.update_user_task(req, tasks.SUBSCRIBE)
-        resp_data = json.loads(resp.content)
-        # We should get back 'ok' status and the token from that
-        # subscriber.
-        self.assertDictEqual(resp_data, {
-            'status': 'ok',
-            'token': self.sub.token,
-            'created': False,
-        })
-        # We should have called update_user with the email, token,
-        # created=False, type=SUBSCRIBE, optin=True
-        uu_mock.assert_called_with({'stuff': 'whanot'},
-                                   self.sub.email, self.sub.token,
-                                   False, tasks.SUBSCRIBE, True)
-
-    @patch('news.utils.update_user.delay')
-    def test_update_user_task_helper_no_sub(self, uu_mock):
-        """
-        Should find sub from submitted email when not provided.
-        """
-        # Request, pretend we were untable to find a subscriber
-        # so we don't set req.subscriber
-        req = self.rf.post('/testing/', {'email': self.sub.email})
-        # See what update_user does
-        resp = views.update_user_task(req, tasks.SUBSCRIBE)
-        # Should be okay
-        self.assertEqual(200, resp.status_code)
-        resp_data = json.loads(resp.content)
-        # Should have found the token for the given email
-        self.assertDictEqual(resp_data, {
-            'status': 'ok',
-            'token': self.sub.token,
-            'created': False,
-        })
-        # We should have called update_user with the email, token,
-        # created=False, type=SUBSCRIBE, optin=True
-        uu_mock.assert_called_with({'email': self.sub.email},
-                                   self.sub.email, self.sub.token,
-                                   False, tasks.SUBSCRIBE, True)
-
-    @patch('news.utils.look_for_user')
-    @patch('news.utils.update_user.delay')
-    def test_update_user_task_helper_create(self, uu_mock, look_for_user):
-        """
-        Should create a user and tell the task about it if email not known.
-        """
-        # Pretend we are unable to find the user in ET
-        look_for_user.return_value = None
-        # Pass in a new email
-        req = self.rf.post('/testing/', {'email': 'donnie@example.com'})
-        resp = views.update_user_task(req, tasks.SUBSCRIBE)
-        # Should work
-        self.assertEqual(200, resp.status_code)
-        # There should be a new subscriber for this email
-        sub = models.Subscriber.objects.get(email='donnie@example.com')
-        resp_data = json.loads(resp.content)
-        # The call should have returned the subscriber's new token
-        self.assertDictEqual(resp_data, {
-            'status': 'ok',
-            'token': sub.token,
-            'created': True,
-        })
-        # We should have called update_user with the email, token,
-        # created=False, type=SUBSCRIBE, optin=True
-        uu_mock.assert_called_with({'email': sub.email},
-                                   sub.email, sub.token,
-                                   True, tasks.SUBSCRIBE, True)
-
-    @patch('news.utils.update_user.delay')
-    def test_update_user_task_helper_error(self, uu_mock):
-        """
-        Should not call the task if no email or token provided.
-        """
-        # Pretend there was no email given - bad request
-        req = self.rf.post('/testing/', {'stuff': 'whanot'})
-        resp = views.update_user_task(req, tasks.SUBSCRIBE)
-        # We don't try to call update_user
-        self.assertFalse(uu_mock.called)
-        # We respond with a 400
-        self.assertEqual(resp.status_code, 400)
-        errors = json.loads(resp.content)
-        # The response also says there was an error
-        self.assertEqual(errors['status'], 'error')
-        # and has a useful error description
-        self.assertEqual(errors['desc'],
-                         MSG_EMAIL_OR_TOKEN_REQUIRED)
-
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_update_send_newsletter_welcome(self, get_user_data, send_message,
                                             apply_updates):
         # When we subscribe to one newsletter, and no confirmation is
@@ -172,8 +73,7 @@ class UpdateUserTest(TestCase):
         rc = update_user(data=data,
                          email=self.sub.email,
                          token=self.sub.token,
-                         created=True,
-                         type=SUBSCRIBE,
+                         api_call_type=SUBSCRIBE,
                          optin=True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         apply_updates.assert_called()
@@ -184,7 +84,7 @@ class UpdateUserTest(TestCase):
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_update_send_no_welcome(self, get_user_data, send_message,
                                     apply_updates):
         """Caller can block sending welcome using trigger_welcome=N
@@ -216,8 +116,7 @@ class UpdateUserTest(TestCase):
         rc = update_user(data=data,
                          email=self.sub.email,
                          token=self.sub.token,
-                         created=True,
-                         type=SUBSCRIBE,
+                         api_call_type=SUBSCRIBE,
                          optin=True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         # We do subscribe them
@@ -227,10 +126,10 @@ class UpdateUserTest(TestCase):
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_update_SET_no_welcome(self, get_user_data, send_message,
                                    apply_updates):
-        """type=SET sends no welcomes"""
+        """api_call_type=SET sends no welcomes"""
 
         # User already exists in ET and is confirmed
         # User does not subscribe to anything yet
@@ -257,15 +156,14 @@ class UpdateUserTest(TestCase):
         rc = update_user(data=data,
                          email=self.sub.email,
                          token=self.sub.token,
-                         created=True,
-                         type=SET,
+                         api_call_type=SET,
                          optin=True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         apply_updates.assert_called()
         # The welcome should NOT have been sent
         self.assertFalse(send_message.called)
 
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     @patch('news.utils.ExactTargetDataExt')
     @patch('news.tasks.ExactTarget')
     def test_update_no_welcome_set(self, et_mock, etde_mock, get_user_data):
@@ -293,8 +191,7 @@ class UpdateUserTest(TestCase):
 
         rc = update_user(data=data, email=self.sub.email,
                          token=self.sub.token,
-                         created=True,
-                         type=SUBSCRIBE, optin=True)
+                         api_call_type=SUBSCRIBE, optin=True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         self.assertFalse(et.trigger_send.called)
 
@@ -303,8 +200,7 @@ class UpdateUserTest(TestCase):
         et.trigger_send.reset_mock()
         rc = update_user(data=data, email=self.sub.email,
                          token=self.sub.token,
-                         created=True,
-                         type=SUBSCRIBE, optin=True)
+                         api_call_type=SUBSCRIBE, optin=True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         self.assertFalse(et.trigger_send.called)
 
@@ -315,8 +211,7 @@ class UpdateUserTest(TestCase):
         # data['welcome_message'] = welcome
         # update_user(data=data, email=self.sub.email,
         #             token=self.sub.token,
-        #             created=True,
-        #             type=SUBSCRIBE, optin=True)
+        #             api_call_type=SUBSCRIBE, optin=True)
         # et.trigger_send.assert_called_with(
         #     welcome,
         #     {
@@ -328,7 +223,7 @@ class UpdateUserTest(TestCase):
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_update_send_newsletters_welcome(self, get_user_data,
                                              send_message,
                                              apply_updates):
@@ -360,8 +255,7 @@ class UpdateUserTest(TestCase):
         rc = update_user(data=data,
                          email=self.sub.email,
                          token=self.sub.token,
-                         created=True,
-                         type=SUBSCRIBE,
+                         api_call_type=SUBSCRIBE,
                          optin=True)
         self.assertEqual(UU_EXEMPT_NEW, rc)
         self.assertEqual(2, send_message.call_count)
@@ -373,7 +267,7 @@ class UpdateUserTest(TestCase):
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_update_user_works_with_no_welcome(self, get_user_data,
                                                send_message,
                                                apply_updates):
@@ -397,15 +291,14 @@ class UpdateUserTest(TestCase):
         get_user_data.return_value = self.get_user_data
         rc = update_user(data=data, email=self.sub.email,
                          token=self.sub.token,
-                         created=True,
-                         type=SUBSCRIBE, optin=True)
+                         api_call_type=SUBSCRIBE, optin=True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         apply_updates.assert_called()
         send_message.assert_called()
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_update_user_works_with_no_lang(self, get_user_data,
                                             send_message,
                                             apply_updates):
@@ -429,8 +322,7 @@ class UpdateUserTest(TestCase):
         get_user_data.return_value = None
         rc = update_user(data=data, email=self.sub.email,
                          token=self.sub.token,
-                         created=True,
-                         type=SUBSCRIBE, optin=True)
+                         api_call_type=SUBSCRIBE, optin=True)
         self.assertEqual(UU_EXEMPT_NEW, rc)
         apply_updates.assert_called()
         send_message.assert_called_with(u'en_Welcome_T',
@@ -440,7 +332,7 @@ class UpdateUserTest(TestCase):
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_ffos_welcome(self, get_user_data, send_message, apply_updates):
         """If the user has subscribed to Firefox OS,
         then we send the welcome for Firefox OS but not for Firefox & You.
@@ -471,8 +363,7 @@ class UpdateUserTest(TestCase):
         rc = update_user(data=data,
                          email=self.sub.email,
                          token=self.sub.token,
-                         created=True,
-                         type=SUBSCRIBE,
+                         api_call_type=SUBSCRIBE,
                          optin=True)
         self.assertEqual(UU_EXEMPT_NEW, rc)
         self.assertEqual(1, send_message.call_count)
@@ -485,7 +376,7 @@ class UpdateUserTest(TestCase):
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     @patch('news.utils.newsletter_fields')
     @patch('news.tasks.ExactTarget')
     def test_update_user_set_works_if_no_newsletters(self, et_mock,
@@ -521,7 +412,7 @@ class UpdateUserTest(TestCase):
         get_user_data.return_value = self.get_user_data
 
         rc = update_user(data, self.sub.email, self.sub.token,
-                         False, SET, True)
+                         SET, True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         # no welcome should be triggered for SET
         self.assertFalse(et.trigger_send.called)
@@ -543,7 +434,7 @@ class UpdateUserTest(TestCase):
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     @patch('news.utils.newsletter_fields')
     @patch('news.utils.ExactTargetDataExt')
     @patch('news.tasks.ExactTarget')
@@ -582,7 +473,7 @@ class UpdateUserTest(TestCase):
         etde.get_record.return_value = self.user_data
 
         rc = update_user(data, self.sub.email, self.sub.token,
-                         False, SUBSCRIBE, True)
+                         SUBSCRIBE, True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         # We should have looked up the user's data
         get_user_data.assert_called()
@@ -597,7 +488,7 @@ class UpdateUserTest(TestCase):
                                           'COUNTRY_': 'US',
                                           })
 
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     @patch('news.utils.newsletter_fields')
     @patch('news.tasks.ExactTarget')
     def test_set_doesnt_update_newsletter(self, et_mock,
@@ -630,7 +521,7 @@ class UpdateUserTest(TestCase):
         get_user_data.return_value = self.get_user_data
         #etde.get_record.return_value = self.user_data
 
-        update_user(data, self.sub.email, self.sub.token, False, SET, True)
+        update_user(data, self.sub.email, self.sub.token, SET, True)
         # We should have looked up the user's data
         self.assertTrue(get_user_data.called)
         # We should not have mentioned this newsletter in our call to ET
@@ -646,7 +537,7 @@ class UpdateUserTest(TestCase):
 
     @skip("FIXME: What should we do if we can't talk to ET")  # FIXME
     @patch('news.tasks.ExactTarget')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_set_does_update_newsletter_on_error(self, get_user_mock, et_mock):
         """
         When setting the newsletters it should ensure that they're set right
@@ -671,7 +562,7 @@ class UpdateUserTest(TestCase):
             'format': 'H',
         }
 
-        update_user(data, self.sub.email, self.sub.token, False, SET, True)
+        update_user(data, self.sub.email, self.sub.token, SET, True)
         # We should have mentioned this newsletter in our call to ET
         et.data_ext.return_value.add_record.assert_called_with(
             ANY,
@@ -685,7 +576,7 @@ class UpdateUserTest(TestCase):
 
     @skip("FIXME: What should we do if we can't talk to ET")  # FIXME
     @patch('news.tasks.ExactTarget')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_unsub_is_not_careful_on_error(self, get_user_mock, et_mock):
         """
         When unsubscribing, we unsubscribe from the requested lists if we can't
@@ -717,7 +608,7 @@ class UpdateUserTest(TestCase):
             'format': 'H',
         }
 
-        update_user(data, self.sub.email, self.sub.token, False, UNSUBSCRIBE,
+        update_user(data, self.sub.email, self.sub.token, UNSUBSCRIBE,
                     True)
         # We should mention both TITLE_UNKNOWN, and TITLE2_UNKNOWN
         et.data_ext.return_value.add_record.assert_called_with(
@@ -730,7 +621,7 @@ class UpdateUserTest(TestCase):
              ANY, 'US'],
         )
 
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     @patch('news.utils.newsletter_fields')
     @patch('news.utils.ExactTargetDataExt')
     @patch('news.tasks.ExactTarget')
@@ -770,8 +661,7 @@ class UpdateUserTest(TestCase):
         # We're only subscribed to TITLE_UNKNOWN though, not the other one
         etde.get_record.return_value = self.user_data
 
-        rc = update_user(data, self.sub.email, self.sub.token, False,
-                         UNSUBSCRIBE, True)
+        rc = update_user(data, self.sub.email, self.sub.token, UNSUBSCRIBE, True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         # We should have looked up the user's data
         self.assertTrue(get_user_data.called)
@@ -788,7 +678,7 @@ class UpdateUserTest(TestCase):
 
     @skip('Do not know what to do in this case')  # FIXME
     @patch('news.tasks.ExactTarget')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_user_data_error(self, get_user_mock, et_mock):
         """
         Bug 871764: error from user data causing subscription to fail
@@ -816,8 +706,7 @@ class UpdateUserTest(TestCase):
         }
 
         with self.assertRaises(NewsletterException):
-            update_user(data, self.sub.email, self.sub.token, False,
-                        SUBSCRIBE, True)
+            update_user(data, self.sub.email, self.sub.token, SUBSCRIBE, True)
         # We should have mentioned this newsletter in our call to ET
         et.data_ext.return_value.add_record.assert_called_with(
             ANY,
@@ -830,7 +719,7 @@ class UpdateUserTest(TestCase):
         )
 
     @patch('news.tasks.ExactTarget')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_update_user_without_format_doesnt_send_format(self,
                                                            get_user_mock,
                                                            et_mock):
@@ -866,8 +755,7 @@ class UpdateUserTest(TestCase):
             'country': 'US',
             'newsletters': 'slug',
         }
-        update_user(data, self.sub.email, self.sub.token, False, SUBSCRIBE,
-                    True)
+        update_user(data, self.sub.email, self.sub.token, SUBSCRIBE, True)
         # We'll pass no format to ET
         et.data_ext.return_value.add_record.assert_called_with(
             ANY,
@@ -888,7 +776,7 @@ class UpdateUserTest(TestCase):
         )
 
     @patch('news.tasks.ExactTarget')
-    @patch('news.views.get_user_data')
+    @patch('news.tasks.get_user_data')
     def test_update_user_wo_format_or_pref(self,
                                            get_user_mock,
                                            et_mock):
@@ -923,8 +811,7 @@ class UpdateUserTest(TestCase):
             'country': 'US',
             'newsletters': 'slug',
         }
-        update_user(data, self.sub.email, self.sub.token, False, SUBSCRIBE,
-                    True)
+        update_user(data, self.sub.email, self.sub.token, SUBSCRIBE, True)
         # We'll pass no format to ET
         et.data_ext.return_value.add_record.assert_called_with(
             ANY,

--- a/news/views.py
+++ b/news/views.py
@@ -13,7 +13,9 @@ from django_statsd.clients import statsd
 from news.models import Newsletter, Subscriber, Interest
 from news.newsletters import newsletter_slugs
 from news.tasks import (
-    MSG_EMAIL_OR_TOKEN_REQUIRED, MSG_USER_NOT_FOUND, SET, SUBSCRIBE, UNSUBSCRIBE,
+    SET,
+    SUBSCRIBE,
+    UNSUBSCRIBE,
     add_sms_user,
     confirm_user,
     send_recovery_message_task,
@@ -24,6 +26,8 @@ from news.tasks import (
     update_student_ambassadors,
 )
 from news.utils import (
+    MSG_EMAIL_OR_TOKEN_REQUIRED,
+    MSG_USER_NOT_FOUND,
     EmailValidationError,
     get_accept_languages,
     get_best_language,


### PR DESCRIPTION
Updates the subscribe endpoint to avoid creating a user account within the view if `sync` is set to `N`, instead creating the user during the delayed task.

In order to make the code I was changing a little cleaner, I also happened to move all the utility functions out of `views.py` and into `utils.py`. I fixed up the tests to pass, and re-wrote the tests for the `subscribe` view as well as the `update_user_task` utility function because sorting through the existing tests (which sort've tested the view, task, and utility all at once) was proving too difficult. Apologies if that makes this hard to follow; I tried to separate the correct things into the two commits to help review.

@pmclanahan r?
