### PR TITLE
No longer raise errors for missing message IDs.

### DIFF
--- a/news/backends/exacttarget.py
+++ b/news/backends/exacttarget.py
@@ -32,7 +32,7 @@ from .common import NewsletterException, NewsletterNoResultsException, \
     UnauthorizedException
 
 
-ET_TIMEOUT = getattr(settings, 'EXACTTARGET_TIMEOUT', 3)
+ET_TIMEOUT = getattr(settings, 'EXACTTARGET_TIMEOUT', 5)
 
 
 class SudsDjangoCache(Cache):

--- a/news/tasks.py
+++ b/news/tasks.py
@@ -306,9 +306,9 @@ def update_fxa_info(email, lang, fxa_id, source_url=None):
 
     record['TOKEN'] = token
 
+    apply_updates(settings.EXACTTARGET_DATA, record)
     welcome = mogrify_message_id(FXACCOUNT_WELCOME, lang, welcome_format)
     send_message(welcome, email, token, welcome_format)
-    apply_updates(settings.EXACTTARGET_DATA, record)
 
 
 @et_task
@@ -546,10 +546,9 @@ def send_message(message_id, email, token, format):
         # Better error messages for some cases. Also there's no point in
         # retrying these
         if 'Invalid Customer Key' in e.message:
-            # Raise the error so it gets logged once, but remember it's a
-            # bad message ID so we don't try again during this process.
+            # remember it's a bad message ID so we don't try again during this process.
             BAD_MESSAGE_ID_CACHE.set(message_id, True)
-            raise BasketError("ET says no such message ID: %r" % message_id)
+            return
         elif 'There are no valid subscribers.' in e.message:
             raise BasketError("ET says: there are no valid subscribers.")
         # we should retry

--- a/news/tests/test_send_welcomes.py
+++ b/news/tests/test_send_welcomes.py
@@ -4,8 +4,7 @@ from mock import patch
 
 from news.backends.common import NewsletterException
 from news.models import Newsletter
-from news.tasks import BasketError, confirm_user, mogrify_message_id, \
-    send_message
+from news.tasks import confirm_user, mogrify_message_id, send_message
 
 
 class TestSendMessage(TestCase):
@@ -18,10 +17,14 @@ class TestSendMessage(TestCase):
         mock_et.trigger_send.side_effect = exc
 
         message_id = "MESSAGE_ID"
-        # Should only raise BaseketError once
-        with self.assertRaises(BasketError):
+        for i in range(10):
             send_message(message_id, 'email', 'token', 'format')
-        send_message(message_id, 'email', 'token', 'format')
+
+        mock_et.trigger_send.assert_called_once_with('MESSAGE_ID', {
+            'EMAIL_ADDRESS_': 'email',
+            'TOKEN': 'token',
+            'EMAIL_FORMAT_': 'format',
+        })
 
 
 class TestSendWelcomes(TestCase):


### PR DESCRIPTION
This was causing failures due to an exception being raised
attempting to send a welcome message before adding the record to
master subscribers. Also we were trying to send a message to a user
that may well not have been in MS which would be an error.

@Osmose r?
