### PR TITLE
Add email format support for get-involved.

### DIFF
--- a/news/models.py
+++ b/news/models.py
@@ -258,12 +258,13 @@ class Interest(models.Model):
     def welcome_id(self):
         return self._welcome_id or self.interest_id
 
-    def notify_stewards(self, email, lang, message):
+    def notify_stewards(self, name, email, lang, message):
         """
         Send an email to the stewards about a new interested
         subscriber.
         """
         email_body = render_to_string('news/get_involved/steward_email.txt', {
+            'contributor_name': name,
             'contributor_email': email,
             'interest': self,
             'lang': lang,

--- a/news/templates/news/get_involved/steward_email.txt
+++ b/news/templates/news/get_involved/steward_email.txt
@@ -1,3 +1,4 @@
+Name: {{ contributor_name }}
 Email: {{ contributor_email }}
 Area of Interest: {{ interest }}
 Language: {{ lang }}

--- a/news/tests/test_models.py
+++ b/news/tests/test_models.py
@@ -90,7 +90,7 @@ class InterestTests(TestCase):
         """
         interest = models.Interest(title='mytest',
                                    default_steward_emails='bob@example.com,bill@example.com')
-        interest.notify_stewards('interested@example.com', 'en-US', 'BYE')
+        interest.notify_stewards('Steve', 'interested@example.com', 'en-US', 'BYE')
 
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]
@@ -109,7 +109,7 @@ class InterestTests(TestCase):
             interest=interest,
             locale='ach',
             emails='ach@example.com')
-        interest.notify_stewards('interested@example.com', 'ach', 'BYE')
+        interest.notify_stewards('Steve', 'interested@example.com', 'ach', 'BYE')
 
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]

--- a/news/tests/test_users.py
+++ b/news/tests/test_users.py
@@ -165,7 +165,7 @@ class UpdateGetInvolvedTests(TestCase):
         email = 'walter@example.com'
         self.get_user_data.return_value = None
         tasks.update_get_involved('bowling', 'en', 'Walter', email,
-                                  'US', 'Y', 'It really tied the room together.', None)
+                                  'US', 'T', 'Y', 'It really tied the room together.', None)
         token = models.Subscriber.objects.get(email=email).token
         self.apply_updates.assert_has_calls([
             call(settings.EXACTTARGET_DATA, {
@@ -174,6 +174,7 @@ class UpdateGetInvolvedTests(TestCase):
                 'LANGUAGE_ISO2': 'en',
                 'COUNTRY_': 'US',
                 'TOKEN': token,
+                'EMAIL_FORMAT_': 'T',
                 'ABOUT_MOZILLA_FLG': 'Y',
                 'ABOUT_MOZILLA_DATE': ANY,
                 'GET_INVOLVED_FLG': 'Y',
@@ -184,13 +185,13 @@ class UpdateGetInvolvedTests(TestCase):
                 'INTEREST': 'bowling',
             }),
         ])
-        self.send_message.assert_called_with('en_welcome_bowling', email, token, 'H')
+        self.send_message.assert_called_with('en_welcome_bowling_T', email, token, 'T')
         self.send_welcomes.assert_called_once_with({
             'email': email,
             'token': token,
             'lang': 'en',
-        }, ['about-mozilla'], 'H')
-        self.interest.notify_stewards.assert_called_with(email, 'en',
+        }, ['about-mozilla'], 'T')
+        self.interest.notify_stewards.assert_called_with('Walter', email, 'en',
                                                          'It really tied the room together.')
 
     @override_settings(EXACTTARGET_DATA='DATA_FOR_DUDE',
@@ -206,7 +207,7 @@ class UpdateGetInvolvedTests(TestCase):
             'newsletters': ['about-mozilla', 'mozilla-and-you', 'get-involved'],
         }
         tasks.update_get_involved('bowling', 'en', 'Walter', email,
-                                  'US', 'Y', 'It really tied the room together.', None)
+                                  'US', 'T', 'Y', 'It really tied the room together.', None)
         self.apply_updates.assert_has_calls([
             call(settings.EXACTTARGET_DATA, {
                 'EMAIL_ADDRESS_': 'walter@example.com',
@@ -224,7 +225,7 @@ class UpdateGetInvolvedTests(TestCase):
         self.send_message.assert_called_with('en_welcome_bowling_T', email, token, 'T')
         # not called because 'about-mozilla' already in newsletters
         self.assertFalse(self.send_welcomes.called)
-        self.interest.notify_stewards.assert_called_with(email, 'en',
+        self.interest.notify_stewards.assert_called_with('Walter', email, 'en',
                                                          'It really tied the room together.')
 
     @override_settings(EXACTTARGET_DATA='DATA_FOR_DUDE',
@@ -243,7 +244,7 @@ class UpdateGetInvolvedTests(TestCase):
             'newsletters': ['mozilla-and-you'],
         }
         tasks.update_get_involved('bowling', 'en', 'Walter', email,
-                                  'US', 'Y', 'It really tied the room together.', None)
+                                  'US', 'T', 'Y', 'It really tied the room together.', None)
         self.apply_updates.assert_has_calls([
             call(settings.EXACTTARGET_DATA, {
                 'EMAIL_ADDRESS_': 'walter@example.com',
@@ -264,7 +265,7 @@ class UpdateGetInvolvedTests(TestCase):
         self.send_message.assert_called_with('en_welcome_bowling_T', email, token, 'T')
         self.send_welcomes.assert_called_once_with(self.get_user_data.return_value,
                                                    ['about-mozilla'], 'T')
-        self.interest.notify_stewards.assert_called_with(email, 'en',
+        self.interest.notify_stewards.assert_called_with('Walter', email, 'en',
                                                          'It really tied the room together.')
 
     @override_settings(EXACTTARGET_DATA='DATA_FOR_DUDE',
@@ -274,7 +275,7 @@ class UpdateGetInvolvedTests(TestCase):
         email = 'walter@example.com'
         self.get_user_data.return_value = None
         tasks.update_get_involved('bowling', 'en', 'Walter', email,
-                                  'US', False, 'It really tied the room together.', None)
+                                  'US', 'H', False, 'It really tied the room together.', None)
         token = models.Subscriber.objects.get(email=email).token
         self.apply_updates.assert_has_calls([
             call(settings.EXACTTARGET_DATA, {
@@ -283,6 +284,7 @@ class UpdateGetInvolvedTests(TestCase):
                 'LANGUAGE_ISO2': 'en',
                 'COUNTRY_': 'US',
                 'TOKEN': token,
+                'EMAIL_FORMAT_': 'H',
                 'GET_INVOLVED_FLG': 'Y',
                 'GET_INVOLVED_DATE': ANY,
             }),
@@ -293,7 +295,7 @@ class UpdateGetInvolvedTests(TestCase):
         ])
         self.send_message.assert_called_with('en_welcome_bowling', email, token, 'H')
         self.assertFalse(self.send_welcomes.called)
-        self.interest.notify_stewards.assert_called_with(email, 'en',
+        self.interest.notify_stewards.assert_called_with('Walter', email, 'en',
                                                          'It really tied the room together.')
 
 

--- a/news/tests/test_views.py
+++ b/news/tests/test_views.py
@@ -27,6 +27,7 @@ class GetInvolvedTests(TestCase):
             'country': 'us',
             'name': 'The Dude',
             'interest_id': 'bowling',
+            'format': 'T',
         }
 
         patcher = patch('news.views.validate_email')
@@ -46,7 +47,7 @@ class GetInvolvedTests(TestCase):
         resp = self._request(self.base_data)
         self.assertEqual(resp['status'], 'ok', resp)
         self.update_get_involved.delay.assert_called_with('bowling', 'en', 'The Dude',
-                                                          'dude@example.com', 'us',
+                                                          'dude@example.com', 'us', 'T',
                                                           False, None, None)
 
     def test_requires_valid_interest(self):
@@ -118,7 +119,7 @@ class GetInvolvedTests(TestCase):
         resp = self._request(self.base_data)
         self.assertEqual(resp['status'], 'ok', resp)
         self.update_get_involved.delay.assert_called_with('bowling', 'en', 'The Dude',
-                                                          'dude@example.com', 'us',
+                                                          'dude@example.com', 'us', 'T',
                                                           'ok', 'I like bowling',
                                                           'https://arewebowlingyet.com/')
 

--- a/news/views.py
+++ b/news/views.py
@@ -162,6 +162,7 @@ def get_involved(request):
         data['name'],
         data['email'],
         data['country'],
+        data.get('format', 'H'),
         data.get('subscribe', False),
         data.get('message', None),
         data.get('source_url', None),


### PR DESCRIPTION
Add "name" info to stewards email.

New get-involved form on bedrock grew support for "format" today. Also noticed
that "name" was being sent to us and not used.
