### PR TITLE
Bug 967795: Make updating the mobile subscribers DE a separate task.

### DIFF
--- a/news/tasks.py
+++ b/news/tasks.py
@@ -777,9 +777,14 @@ def add_sms_user(send_name, mobile_number, optin):
         return add_sms_user.retry(exc=error)
 
     if optin:
-        record = {'Phone': mobile_number, 'SubscriberKey': mobile_number}
-        data_ext = ExactTargetDataExt(settings.EXACTTARGET_USER, settings.EXACTTARGET_PASS)
-        data_ext.add_record('Mobile_Subscribers', record.keys(), record.values())
+        add_sms_user_optin.delay(mobile_number)
+
+
+@et_task
+def add_sms_user_optin(mobile_number):
+    record = {'Phone': mobile_number, 'SubscriberKey': mobile_number}
+    data_ext = ExactTargetDataExt(settings.EXACTTARGET_USER, settings.EXACTTARGET_PASS)
+    data_ext.add_record('Mobile_Subscribers', record.keys(), record.values())
 
 
 @et_task


### PR DESCRIPTION
If the data-extension update fails the task will retry, and send another
SMS to the user. Moving this part to its own task means that both calls
will retry independently.

I believe the current tests cover this well enough in that they ensure
that the ET stuff is called if optin is true.
