### PR TITLE
Fix bug 1088779: Fix ET error handling around views and tasks.

### DIFF
--- a/news/backends/common.py
+++ b/news/backends/common.py
@@ -6,7 +6,11 @@ class UnauthorizedException(Exception):
 
 class NewsletterException(Exception):
     """Error when trying to talk to the the email server."""
-    pass
+
+    def __init__(self, msg=None, error_code=None, status_code=None):
+        self.error_code = error_code
+        self.status_code = status_code
+        super(NewsletterException, self).__init__(msg)
 
 
 class NewsletterNoResultsException(NewsletterException):

--- a/news/tasks.py
+++ b/news/tasks.py
@@ -476,10 +476,6 @@ def update_user(data, email, token, api_call_type, optin):
             'lang': lang,
             'status': 'ok',
         }
-    elif user_data.get('status', 'error') != 'ok':
-        # Error talking to ET - raise so we retry later
-        msg = "Some error with Exact Target: %r" % user_data
-        raise NewsletterException(msg)
 
     if lang:
         # User asked for a language change. Use the new language from
@@ -744,14 +740,15 @@ def confirm_user(token, user_data):
     if user_data is None:
         from .utils import get_user_data   # Avoid circular import
         user_data = get_user_data(token=token)
+
     if user_data is None:
         raise BasketError(MSG_USER_NOT_FOUND)
-    if user_data['status'] == 'error':
-        raise NewsletterException('error getting user data')
+
     if user_data['confirmed']:
-        log.info("In confirm_user, user with token %s "
-                 "is already confirmed" % token)
+        log.info('In confirm_user, user with token %s '
+                 'is already confirmed' % token)
         return
+
     if not 'email' in user_data or not user_data['email']:
         raise BasketError('token has no email in ET')
 

--- a/news/tests/test_confirm.py
+++ b/news/tests/test_confirm.py
@@ -318,18 +318,15 @@ class TestConfirmationLogic(TestCase):
 @patch('news.tasks.send_welcomes')
 @patch('news.tasks.apply_updates')
 class TestConfirmTask(TestCase):
-    def test_error(self, apply_updates, send_welcomes):
+    @patch('news.utils.lookup_subscriber')
+    def test_error(self, lookup_subscriber, apply_updates, send_welcomes):
         """
         If user_data shows an error talking to ET, the task raises
         an exception so our task logic will retry
         """
-        user_data = {
-            'status': 'error',
-            'desc': 'TESTERROR',
-        }
-        token = "TOKEN"
+        lookup_subscriber.side_effect = NewsletterException('Stuffs broke yo.')
         with self.assertRaises(NewsletterException):
-            confirm_user(token, user_data)
+            confirm_user('token', None)
         self.assertFalse(apply_updates.called)
         self.assertFalse(send_welcomes.called)
 

--- a/news/tests/test_tasks.py
+++ b/news/tests/test_tasks.py
@@ -12,6 +12,7 @@ from news.tasks import (
     add_sms_user,
     et_task,
     mogrify_message_id,
+    NewsletterException,
     RECOVERY_MESSAGE_ID,
     send_recovery_message_task,
     SUBSCRIBE,
@@ -77,6 +78,15 @@ class RecoveryMessageTask(TestCase):
         # Should log error and return
         mock_look_for_user.return_value = None
         send_recovery_message_task(self.email)
+        self.assertFalse(mock_send.called)
+
+    def test_et_error(self, mock_look_for_user, mock_send):
+        """Error talking to Basket. I'm shocked, SHOCKED!"""
+        mock_look_for_user.side_effect = NewsletterException('ET has failed to achieve.')
+
+        with self.assertRaises(NewsletterException):
+            send_recovery_message_task(self.email)
+
         self.assertFalse(mock_send.called)
 
     def test_email_only_in_et(self, mock_look_for_user, mock_send):


### PR DESCRIPTION
This refactors a lot about how ET errors are handled. They were being
converted to dicts of error information which needed to be detected and
dealt with by calling functions. Now they raise exceptions with proper
information attached that can bubble up in tasks to cause retries, or be
converted to error reponses in views.
