### PR TITLE
Bug 1090432: Retry when we see "No valid subscriber" error.

### DIFF
--- a/news/tests/test_confirm.py
+++ b/news/tests/test_confirm.py
@@ -404,7 +404,7 @@ class TestSendWelcomes(TestCase):
         }
         confirm_user(token, user_data)
         expected_welcome = "%s_%s_%s" % (lang, welcome, format)
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -434,7 +434,7 @@ class TestSendWelcomes(TestCase):
         confirm_user(token, user_data)
         # Lang code is lowercased. And we don't append anything for HTML.
         expected_welcome = "%s_%s" % (lang.lower(), welcome)
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -465,7 +465,7 @@ class TestSendWelcomes(TestCase):
         confirm_user(token, user_data)
         # They're getting English. And we don't append anything for HTML.
         expected_welcome = "en_%s" % welcome
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -495,7 +495,7 @@ class TestSendWelcomes(TestCase):
         confirm_user(token, user_data)
         # They're getting pt. And we don't append anything for HTML.
         expected_welcome = "pt_%s" % welcome
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -525,7 +525,7 @@ class TestSendWelcomes(TestCase):
         confirm_user(token, user_data)
         # They're getting pt. And we don't append anything for HTML.
         expected_welcome = "pt_%s" % welcome
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -554,4 +554,4 @@ class TestSendWelcomes(TestCase):
         }
         confirm_user(token, user_data)
         expected_welcome = 'en_' + welcome
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)

--- a/news/tests/test_send_confirm_notice.py
+++ b/news/tests/test_send_confirm_notice.py
@@ -31,28 +31,28 @@ class TestSendConfirmNotice(TestCase):
         """Test newsletter that has no explicit confirm"""
         send_confirm_notice(self.email, self.token, "en", "H", ['slug2'])
         expected_message = mogrify_message_id(CONFIRMATION_MESSAGE, 'en', 'H')
-        send_message.assert_called_with(expected_message,
-                                        self.email,
-                                        self.token,
-                                        'H')
+        send_message.delay.assert_called_with(expected_message,
+                                              self.email,
+                                              self.token,
+                                              'H')
 
     def test_default_confirm_notice_T(self, send_message):
         """Test newsletter that has no explicit confirm"""
         send_confirm_notice(self.email, self.token, "es", "T", ['slug2'])
         expected_message = mogrify_message_id(CONFIRMATION_MESSAGE, 'es', 'T')
-        send_message.assert_called_with(expected_message,
-                                        self.email,
-                                        self.token,
-                                        'T')
+        send_message.delay.assert_called_with(expected_message,
+                                              self.email,
+                                              self.token,
+                                              'T')
 
     def test_default_confirm_notice_short_for_long(self, send_message):
         """Test using short form of lang that's in the newsletter list as a long lang"""
         send_confirm_notice(self.email, self.token, "rr", "H", ['slug2'])
         expected_message = mogrify_message_id(CONFIRMATION_MESSAGE, 'rr', 'H')
-        send_message.assert_called_with(expected_message,
-                                        self.email,
-                                        self.token,
-                                        'H')
+        send_message.delay.assert_called_with(expected_message,
+                                              self.email,
+                                              self.token,
+                                              'H')
 
     ### known long lang
 
@@ -60,19 +60,19 @@ class TestSendConfirmNotice(TestCase):
         """Test newsletter that has no explicit confirm with long lang code"""
         send_confirm_notice(self.email, self.token, "es-ES", "H", ['slug2'])
         expected_message = mogrify_message_id(CONFIRMATION_MESSAGE, 'es', 'H')
-        send_message.assert_called_with(expected_message,
-                                        self.email,
-                                        self.token,
-                                        'H')
+        send_message.delay.assert_called_with(expected_message,
+                                              self.email,
+                                              self.token,
+                                              'H')
 
     def test_default_confirm_notice_long_lang_T(self, send_message):
         """Test newsletter that has no explicit confirm with long lang code"""
         send_confirm_notice(self.email, self.token, "es-ES", "T", ['slug2'])
         expected_message = mogrify_message_id(CONFIRMATION_MESSAGE, 'es', 'T')
-        send_message.assert_called_with(expected_message,
-                                        self.email,
-                                        self.token,
-                                        'T')
+        send_message.delay.assert_called_with(expected_message,
+                                              self.email,
+                                              self.token,
+                                              'T')
 
     ### bad lang
 
@@ -97,19 +97,19 @@ class TestSendConfirmNotice(TestCase):
         """Test newsletter that has explicit confirm message"""
         send_confirm_notice(self.email, self.token, "en", "H", ['slug1'])
         expected_message = 'en_confirm1'
-        send_message.assert_called_with(expected_message,
-                                        self.email,
-                                        self.token,
-                                        'H')
+        send_message.delay.assert_called_with(expected_message,
+                                              self.email,
+                                              self.token,
+                                              'H')
 
     def test_explicit_confirm_notice_T(self, send_message):
         """Test newsletter that has explicit confirm message"""
         send_confirm_notice(self.email, self.token, "en", "T", ['slug1'])
         expected_message = 'en_confirm1_T'
-        send_message.assert_called_with(expected_message,
-                                        self.email,
-                                        self.token,
-                                        'T')
+        send_message.delay.assert_called_with(expected_message,
+                                              self.email,
+                                              self.token,
+                                              'T')
 
     ### known long lang
 
@@ -117,19 +117,19 @@ class TestSendConfirmNotice(TestCase):
         """Test newsletter that has explicit confirm message with long lang"""
         send_confirm_notice(self.email, self.token, "en-US", "H", ['slug1'])
         expected_message = 'en_confirm1'
-        send_message.assert_called_with(expected_message,
-                                        self.email,
-                                        self.token,
-                                        'H')
+        send_message.delay.assert_called_with(expected_message,
+                                              self.email,
+                                              self.token,
+                                              'H')
 
     def test_explicit_confirm_notice_long_lang_T(self, send_message):
         """Test newsletter that has explicit confirm message with long lang"""
         send_confirm_notice(self.email, self.token, "en-US", "T", ['slug1'])
         expected_message = 'en_confirm1_T'
-        send_message.assert_called_with(expected_message,
-                                        self.email,
-                                        self.token,
-                                        'T')
+        send_message.delay.assert_called_with(expected_message,
+                                              self.email,
+                                              self.token,
+                                              'T')
 
     ### bad lang
 

--- a/news/tests/test_send_welcomes.py
+++ b/news/tests/test_send_welcomes.py
@@ -86,7 +86,7 @@ class TestSendWelcomes(TestCase):
         }
         confirm_user(token, user_data)
         expected_welcome = "%s_%s_%s" % (lang, welcome, format)
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -116,7 +116,7 @@ class TestSendWelcomes(TestCase):
         confirm_user(token, user_data)
         # Lang code is lowercased. And we don't append anything for HTML.
         expected_welcome = "%s_%s" % (lang.lower(), welcome)
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -147,7 +147,7 @@ class TestSendWelcomes(TestCase):
         confirm_user(token, user_data)
         # They're getting English. And we don't append anything for HTML.
         expected_welcome = "en_%s" % welcome
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -177,7 +177,7 @@ class TestSendWelcomes(TestCase):
         confirm_user(token, user_data)
         # They're getting pt. And we don't append anything for HTML.
         expected_welcome = "pt_%s" % welcome
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -207,7 +207,7 @@ class TestSendWelcomes(TestCase):
         confirm_user(token, user_data)
         # They're getting pt. And we don't append anything for HTML.
         expected_welcome = "pt_%s" % welcome
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)
 
     @patch('news.tasks.send_message')
     @patch('news.tasks.apply_updates')
@@ -236,4 +236,4 @@ class TestSendWelcomes(TestCase):
         }
         confirm_user(token, user_data)
         expected_welcome = 'en_' + welcome
-        send_message.assert_called_with(expected_welcome, email, token, format)
+        send_message.delay.assert_called_with(expected_welcome, email, token, format)

--- a/news/tests/test_tasks.py
+++ b/news/tests/test_tasks.py
@@ -108,8 +108,8 @@ class RecoveryMessageTask(TestCase):
         subscriber = Subscriber.objects.get(email=self.email)
         self.assertEqual('USERTOKEN', subscriber.token)
         message_id = mogrify_message_id(RECOVERY_MESSAGE_ID, lang, format)
-        mock_send.assert_called_with(message_id, self.email,
-                                     subscriber.token, format)
+        mock_send.delay.assert_called_with(message_id, self.email,
+                                           subscriber.token, format)
 
     def test_email_only_in_basket(self, mock_look_for_user, mock_send):
         """Email known in basket, not in ET"""
@@ -136,8 +136,8 @@ class RecoveryMessageTask(TestCase):
         }
         send_recovery_message_task(self.email)
         message_id = mogrify_message_id(RECOVERY_MESSAGE_ID, lang, format)
-        mock_send.assert_called_with(message_id, self.email,
-                                     subscriber.token, format)
+        mock_send.delay.assert_called_with(message_id, self.email,
+                                           subscriber.token, format)
 
 
 class UpdateUserTests(TestCase):

--- a/news/tests/test_update_user.py
+++ b/news/tests/test_update_user.py
@@ -78,9 +78,9 @@ class UpdateUserTest(TestCase):
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         apply_updates.assert_called()
         # The welcome should have been sent
-        send_message.assert_called()
-        send_message.assert_called_with('en_' + welcome_id, self.sub.email,
-                                        self.sub.token, 'H')
+        send_message.delay.assert_called()
+        send_message.delay.assert_called_with('en_' + welcome_id, self.sub.email,
+                                              self.sub.token, 'H')
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
@@ -258,8 +258,8 @@ class UpdateUserTest(TestCase):
                          api_call_type=SUBSCRIBE,
                          optin=True)
         self.assertEqual(UU_EXEMPT_NEW, rc)
-        self.assertEqual(2, send_message.call_count)
-        calls_args = [x[0] for x in send_message.call_args_list]
+        self.assertEqual(2, send_message.delay.call_count)
+        calls_args = [x[0] for x in send_message.delay.call_args_list]
         self.assertIn(('en_WELCOME1', self.sub.email, self.sub.token, 'H'),
                       calls_args)
         self.assertIn(('en_WELCOME2', self.sub.email, self.sub.token, 'H'),
@@ -294,7 +294,7 @@ class UpdateUserTest(TestCase):
                          api_call_type=SUBSCRIBE, optin=True)
         self.assertEqual(UU_ALREADY_CONFIRMED, rc)
         apply_updates.assert_called()
-        send_message.assert_called()
+        send_message.delay.assert_called()
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
@@ -325,10 +325,10 @@ class UpdateUserTest(TestCase):
                          api_call_type=SUBSCRIBE, optin=True)
         self.assertEqual(UU_EXEMPT_NEW, rc)
         apply_updates.assert_called()
-        send_message.assert_called_with(u'en_Welcome_T',
-                                        self.sub.email,
-                                        self.sub.token,
-                                        'T')
+        send_message.delay.assert_called_with(u'en_Welcome_T',
+                                              self.sub.email,
+                                              self.sub.token,
+                                              'T')
 
     @patch('news.tasks.apply_updates')
     @patch('news.tasks.send_message')
@@ -366,8 +366,8 @@ class UpdateUserTest(TestCase):
                          api_call_type=SUBSCRIBE,
                          optin=True)
         self.assertEqual(UU_EXEMPT_NEW, rc)
-        self.assertEqual(1, send_message.call_count)
-        calls_args = [x[0] for x in send_message.call_args_list]
+        self.assertEqual(1, send_message.delay.call_count)
+        calls_args = [x[0] for x in send_message.delay.call_args_list]
         self.assertIn(('en_FFOS_WELCOME', self.sub.email, self.sub.token, 'H'),
                       calls_args)
         self.assertNotIn(('en_FF&Y_WELCOME', self.sub.email,

--- a/news/tests/test_users.py
+++ b/news/tests/test_users.py
@@ -50,8 +50,8 @@ class UpdateFxAInfoTest(TestCase):
             'MODIFIED_DATE_': ANY,
         })
         self.get_external_user_data.assert_called_with(email=email)
-        self.send_message.assert_called_with('de_{0}'.format(tasks.FXACCOUNT_WELCOME),
-                                             email, sub.token, 'H')
+        self.send_message.delay.assert_called_with('de_{0}'.format(tasks.FXACCOUNT_WELCOME),
+                                                   email, sub.token, 'H')
 
     def test_user_in_et_not_basket(self):
         """A user could exist in basket but not ET, should still work."""
@@ -73,8 +73,8 @@ class UpdateFxAInfoTest(TestCase):
             'MODIFIED_DATE_': ANY,
         })
         self.get_external_user_data.assert_called_with(email=email)
-        self.send_message.assert_called_with('de_{0}'.format(tasks.FXACCOUNT_WELCOME),
-                                             email, sub.token, 'H')
+        self.send_message.delay.assert_called_with('de_{0}'.format(tasks.FXACCOUNT_WELCOME),
+                                                   email, sub.token, 'H')
 
     def test_existing_user_not_in_basket(self):
         """Adding a user already in ET but not basket should preserve token."""
@@ -100,8 +100,8 @@ class UpdateFxAInfoTest(TestCase):
             'FXA_LANGUAGE_ISO2': 'de',
         })
         self.get_external_user_data.assert_called_with(email=email)
-        self.send_message.assert_called_with('de_{0}'.format(tasks.FXACCOUNT_WELCOME),
-                                             email, sub.token, '')
+        self.send_message.delay.assert_called_with('de_{0}'.format(tasks.FXACCOUNT_WELCOME),
+                                                   email, sub.token, '')
 
     def test_existing_user(self):
         """Adding a fxa_id to an existing user shouldn't modify other things."""
@@ -125,8 +125,8 @@ class UpdateFxAInfoTest(TestCase):
             'MODIFIED_DATE_': ANY,
             'FXA_LANGUAGE_ISO2': 'de',
         })
-        self.send_message.assert_called_with('de_{0}_T'.format(tasks.FXACCOUNT_WELCOME),
-                                             email, sub.token, 'T')
+        self.send_message.delay.assert_called_with('de_{0}_T'.format(tasks.FXACCOUNT_WELCOME),
+                                                   email, sub.token, 'T')
 
 
 @override_settings(EXACTTARGET_DATA='DATA_FOR_DUDE',
@@ -185,7 +185,7 @@ class UpdateGetInvolvedTests(TestCase):
                 'INTEREST': 'bowling',
             }),
         ])
-        self.send_message.assert_called_with('en_welcome_bowling_T', email, token, 'T')
+        self.send_message.delay.assert_called_with('en_welcome_bowling_T', email, token, 'T')
         self.send_welcomes.assert_called_once_with({
             'email': email,
             'token': token,
@@ -232,7 +232,7 @@ class UpdateGetInvolvedTests(TestCase):
                 'INTEREST': 'bowling',
             }),
         ])
-        self.send_message.assert_called_with('en_welcome_bowling_T', email, token, 'T')
+        self.send_message.delay.assert_called_with('en_welcome_bowling_T', email, token, 'T')
         # not called because 'about-mozilla' already in newsletters
         self.assertFalse(self.send_welcomes.called)
         self.interest.notify_stewards.assert_called_with('Walter', email, 'en',
@@ -271,7 +271,7 @@ class UpdateGetInvolvedTests(TestCase):
                 'INTEREST': 'bowling',
             }),
         ])
-        self.send_message.assert_called_with('en_welcome_bowling_T', email, token, 'T')
+        self.send_message.delay.assert_called_with('en_welcome_bowling_T', email, token, 'T')
         self.send_welcomes.assert_called_once_with(self.get_user_data.return_value,
                                                    ['about-mozilla'], 'T')
         self.interest.notify_stewards.assert_called_with('Walter', email, 'en',
@@ -300,7 +300,7 @@ class UpdateGetInvolvedTests(TestCase):
                 'INTEREST': 'bowling',
             }),
         ])
-        self.send_message.assert_called_with('en_welcome_bowling', email, token, 'H')
+        self.send_message.delay.assert_called_with('en_welcome_bowling', email, token, 'H')
         self.assertFalse(self.send_welcomes.called)
         self.interest.notify_stewards.assert_called_with('Walter', email, 'en',
                                                          'It really tied the room together.')


### PR DESCRIPTION
Bug 1090007: Move sending triggerd emails to a task.
