### PR TITLE
Bug 1090990: Fix unicode error for emails with non-ascii domains.

### DIFF
--- a/news/utils.py
+++ b/news/utils.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email as dj_validate_email
 from django.http import HttpResponse
+from django.utils.encoding import force_unicode
 from django.utils.translation.trans_real import parse_accept_lang_header
 
 # Get error codes from basket-client so users see the same definitions
@@ -445,15 +446,14 @@ def get_best_language(languages):
     return languages[0]
 
 
-def validate_email(data):
-    """Validates that the email key in the passed dict is valid.
+def validate_email(email):
+    """Validates that the email is valid.
 
-    Alternately checks that the 'validated' arg was passed in.
     Returns None on success and raises a ValidationError if
     invalid. The exception will have a 'suggestion' parameter
     that will contain the suggested email address or None.
 
-    @param data: dict. usually the POST data
+    @param email: unicode string, email address hopefully
     @return: None if email address in the 'email' key is valid
     @raise: EmailValidationError if 'email' key is invalid
     """
@@ -462,7 +462,7 @@ def validate_email(data):
     # TODO: Find a more robust solution
     #       Possibly ET's email validation API.
     try:
-        dj_validate_email(data.get('email', None))
+        dj_validate_email(force_unicode(email))
     except ValidationError:
         raise EmailValidationError('Invalid email address')
 

--- a/news/views.py
+++ b/news/views.py
@@ -2,6 +2,7 @@ import re
 
 from django.conf import settings
 from django.shortcuts import render
+from django.utils.encoding import force_unicode
 from django.views.decorators.cache import cache_control, never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
@@ -185,6 +186,9 @@ def subscribe(request):
             # Can't use QueryDict since the string is not url-encoded.
             # It will convert '+' to ' ' for example.
             data = dict(pair.split('=') for pair in raw_request.split('&'))
+            email = data.get('email')
+            if email:
+                data['email'] = force_unicode(email)
             statsd.incr('subscribe-fxos-workaround')
         else:
             return HttpResponseJSON({
@@ -217,7 +221,7 @@ def subscribe(request):
             }, 401)
 
     try:
-        validate_email(data)
+        validate_email(data.get('email'))
     except EmailValidationError as e:
         return invalid_email_response(e)
 


### PR DESCRIPTION
This fixes the unicode decode error, but validation will still fail for emails
with non-assci user components (before @). Open question in the bug on what we should
consider valid here based on what ET considers valid.
