### PR TITLE
Bug 1119313: Upgrade Django to 1.6.9.

### DIFF
--- a/news/models.py
+++ b/news/models.py
@@ -90,6 +90,7 @@ class Newsletter(models.Model):
                   "newsletter supports",
     )
     requires_double_optin = models.BooleanField(
+        default=False,
         help_text="True if subscribing to this newsletter requires someone"
                   "to respond to a confirming email.",
     )


### PR DESCRIPTION
Django 1.6.x no longer has a default of False for
BooleanFields.