### PR TITLE
Fix bug 1102652: Accept language values with underscores.

### DIFF
--- a/news/tests/test__utils.py
+++ b/news/tests/test__utils.py
@@ -188,12 +188,21 @@ class TestGetAcceptLanguages(TestCase):
         self._test('ja-JP-mac,ja-JP;q=0.7,ja;q=0.3', ['ja-JP', 'ja'])
         self._test('foo,bar;q=0.5', ['foo', 'bar'])
 
+    def test_invalid_lang_codes_underscores(self):
+        """
+        Even though 'en_US' is invalid according to the spec, we get what it means.
+        Let's accept it. Bug 1102652.
+        """
+        self._test('en_US', ['en'])
+        self._test('pt_pt,fr;q=0.8,it_it;q=0.5,de;q=0.3',
+                   ['pt-PT', 'fr', 'it-IT', 'de'])
+
     def test_invalid_lang_codes(self):
         """
         Should return a list of valid lang codes or an empty list
         """
         self._test('', [])
-        self._test('en_us,en*;q=0.5', [])
+        self._test('en/us,en*;q=0.5', [])
         self._test('Chinese,zh-cn;q=0.5', ['zh-CN'])
 
 

--- a/news/utils.py
+++ b/news/utils.py
@@ -422,6 +422,9 @@ def get_accept_languages(header_value):
     languages = []
     pattern = re.compile(r'^([A-Za-z]{2,3})(?:-([A-Za-z]{2})(?:-[A-Za-z0-9]+)?)?$')
 
+    # bug 1102652
+    header_value = header_value.replace('_', '-')
+
     try:
         parsed = parse_accept_lang_header(header_value)
     except ValueError:  # see https://code.djangoproject.com/ticket/21078


### PR DESCRIPTION
"en_US" is not a valid Accept-Language header value, but
we should accept it for FxA because they get some like that
and we clearly know what it means.