### PR TITLE
Fix bug 1185999: Look up users in Confirmed DE properly.

### DIFF
--- a/news/tests/test_users.py
+++ b/news/tests/test_users.py
@@ -527,6 +527,22 @@ class TestGetUserData(TestCase):
         mock_user = {'token': 'Just a dummy user'}
         self.check_get_user(None, mock_user, ANY, False, mock_user)
 
+    @patch('news.utils.look_for_user')
+    def test_look_for_user_called_correctly_confirmation(self, mock_look_for_user):
+        """
+        If user is looked for by email, is not in master
+        but is in opt_in, make sure confirmation is called
+        correctly, and that if not in confirmation return a "pending" state.
+        """
+        mock_look_for_user.side_effect = [None, {'token': 'dude'}, None]
+        result = get_user_data(email='dude@example.com')
+        self.assertTrue(result['pending'])
+        self.assertFalse(result['master'])
+        self.assertFalse(result['confirmed'])
+        # must be called with token returned from previous call only
+        mock_look_for_user.assert_called_with(settings.EXACTTARGET_CONFIRMATION,
+                                              None, 'dude', ['Token'])
+
 
 class UserTest(TestCase):
     def setUp(self):

--- a/news/utils.py
+++ b/news/utils.py
@@ -29,7 +29,7 @@ from news.newsletters import (
 )
 
 
-## Error messages
+# Error messages
 MSG_TOKEN_REQUIRED = 'Must have valid token for this request'
 MSG_EMAIL_OR_TOKEN_REQUIRED = 'Must have valid token OR email for this request'
 MSG_USER_NOT_FOUND = 'User not found'
@@ -396,9 +396,12 @@ def get_user_data(token=None, email=None, sync_data=False):
             # Confirmed database.  Do it simply; the confirmed database
             # doesn't have most of the user's data, just their token.
             if look_for_user(settings.EXACTTARGET_CONFIRMATION,
-                             email, token, ['Token']):
+                             None, user_data['token'], ['Token']):
                 # Ah-ha, they're in the Confirmed DB so they did confirm
                 confirmed = True
+            else:
+                # They're in the optin db, but not confirmed, so we wait
+                pending = True
 
         user_data['confirmed'] = confirmed
         user_data['pending'] = pending


### PR DESCRIPTION
From the bug:

> The `utils.get_user_data` function was attempting to look for users that were not in `Master_Subscribers`, but were in `Double_Opt_In` in the `Confirmation` data extension using whatever info was passed to the function. When the lookup was via email, the email address was used, but the `Confirmation` extension does not have an `EMAIL_ADDRESS_` column. This caused errors for all of these users and basket was returning a 400 error. The expected behavior is for basket to return a 200 response indicating that the user was found, but unconfirmed.