### PR TITLE
LEGACY: Allow api key param api_key

### DIFF
--- a/news/utils.py
+++ b/news/utils.py
@@ -82,8 +82,9 @@ def has_valid_api_key(request):
     # The API key could be the query parameter 'api-key' or the
     # request header 'X-api-key'.
 
-    api_key = request.REQUEST.get('api-key', None) or\
-        request.META.get('HTTP_X_API_KEY', None)
+    api_key = (request.REQUEST.get('api-key', None) or
+               request.REQUEST.get('api_key', None) or
+               request.META.get('HTTP_X_API_KEY', None))
     return APIUser.is_valid(api_key)
 
 


### PR DESCRIPTION
Backport of e5198c56b1c51fed5504b094f88ca83a6e1bcb6e for legacy
deployments.