### PR TITLE
Add a read-only-mode for use with replicant DB

### DIFF
--- a/news/tasks.py
+++ b/news/tasks.py
@@ -123,14 +123,15 @@ class ETTask(Task):
         """
         statsd.incr(self.name + '.failure')
         log.error("Task failed: %s" % self.name, exc_info=einfo.exc_info)
-        FailedTask.objects.create(
-            task_id=task_id,
-            name=self.name,
-            args=args,
-            kwargs=kwargs,
-            exc=repr(exc),
-            einfo=str(einfo),  # str() gives more info than repr() on celery.datastructures.ExceptionInfo
-        )
+        if settings.STORE_TASK_FAILURES:
+            FailedTask.objects.create(
+                task_id=task_id,
+                name=self.name,
+                args=args,
+                kwargs=kwargs,
+                exc=repr(exc),
+                einfo=str(einfo),  # str() gives more info than repr() on celery.datastructures.ExceptionInfo
+            )
 
     def on_retry(self, exc, task_id, args, kwargs, einfo):
         """Retry handler.

--- a/urls.py
+++ b/urls.py
@@ -1,21 +1,15 @@
 from django.conf import settings
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 from django.contrib import admin
 
 
-admin.autodiscover()
-
-
-urlpatterns = patterns('',
-    (r'^admin/doc/', include('django.contrib.admindocs.urls')),
-    (r'^admin/', include(admin.site.urls)),
-    (r'^news/', include('news.urls'))
+urlpatterns = (
+    url(r'^news/', include('news.urls')),
 )
 
-if settings.DEBUG:
-    # Remove leading and trailing slashes so the regex matches.
-    media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
-    urlpatterns += patterns('',
-        (r'^%s/(?P<path>.*)$' % media_url, 'django.views.static.serve',
-         {'document_root': settings.MEDIA_ROOT}),
+if not settings.DISABLE_ADMIN:
+    admin.autodiscover()
+    urlpatterns += (
+        url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+        url(r'^admin/', include(admin.site.urls)),
     )


### PR DESCRIPTION
When using the replicant DB in eu-west RDS basket will need to be in RO mode. This settings addition will allow us to disable the admin and task failure DB storage.