### PR TITLE
deploy: Add datacenter variable in remote and branch.

### DIFF
--- a/bin/deploy-travis.sh
+++ b/bin/deploy-travis.sh
@@ -19,6 +19,6 @@ openssl aes-256-cbc -K $encrypted_83630750896a_key -iv $encrypted_83630750896a_i
 chmod 600 .travis/id_rsa
 ssh-add .travis/id_rsa
 
-git remote add deis-$1 ssh://git@deis.$2.moz.works:2222/basket-$1.git
-git checkout -b travis-deploy-$1
-git push -f deis-$1 travis-deploy-$1:master
+git remote add deis-$1-$2 ssh://git@deis.$2.moz.works:2222/basket-$1.git
+git checkout -b travis-deploy-$1-$2
+git push -f deis-$1-$2 travis-deploy-$1:master


### PR DESCRIPTION
Current deploy to eu-west fails because remote `deis-stage` exists. Similar issue with `git checkout -b` and `deis-stage` branch. I added the datacenter `$2` variable in the names to fix this.