### PR TITLE
Skip DB migration in RO mode

### DIFF
--- a/bin/run-prod.sh
+++ b/bin/run-prod.sh
@@ -2,7 +2,11 @@
 
 # need to do this here because docker build has no env
 python manage.py collectstatic --noinput
-python manage.py migrate --noinput
+
+READ_ONLY_MODE=$(echo "$READ_ONLY_MODE" | tr '[:upper:]' '[:lower:]')
+if [[ "$READ_ONLY_MODE" != "true" ]]; then
+    python manage.py migrate --noinput
+fi
 
 echo "$GIT_SHA" > static/revision.txt
 


### PR DESCRIPTION
The only problem is that `$READ_ONLY_MODE` might be `False`, but this would think it was true regardless. I don't think this will be a problem in practice, but it's something to keep in mind. To really fix it properly we'd probably have to wrap the `migrate` management command and check the setting in Python.