### PR TITLE
Ignore the "no valid subscribers" errors

### DIFF
--- a/news/tests/test_tasks.py
+++ b/news/tests/test_tasks.py
@@ -200,7 +200,7 @@ class ETTaskTests(TestCase):
         # have to use run() to make sure our request above is used
         myfunc.run()
 
-        myfunc.retry.assert_called_with(exc=error, countdown=16 * 60)
+        myfunc.retry.assert_called_with(countdown=16 * 60)
 
 
 class AddFxaActivityTests(TestCase):


### PR DESCRIPTION
They are due to invalid or non-existant or known-bad email addresses and will never work, so we shouldn't be storing the failed tasks nor seeing these as errors in New Relic.

Also add some more statsd data on tasks that fail after the maximum number of retries.