### PR TITLE
Fix bug 1261465: Send recover message only in supported languages

### DIFF
--- a/news/tasks.py
+++ b/news/tasks.py
@@ -787,13 +787,6 @@ def attempt_fix(ext_name, record, task, e):
 
 @et_task
 def send_recovery_message_task(email):
-    # Have to import here to avoid circular import - that means that for
-    # testing, this can't be mocked. Mock look_for_user instead.
-    from news.views import get_user_data
-
-    # We should check ET so we can get format and lang if they exist.
-    # If they don't exist, then we can create a basket subscriber.
-
     user_data = get_user_data(email=email)
     if not user_data:
         log.warn("In send_recovery_message_task, email not known: %s" % email)
@@ -802,6 +795,9 @@ def send_recovery_message_task(email):
     # make sure we have a language and format, no matter what ET returned
     lang = user_data.get('lang', 'en') or 'en'
     format = user_data.get('format', 'H') or 'H'
+
+    if lang not in settings.RECOVER_MSG_LANGS:
+        lang = 'en'
 
     message_id = mogrify_message_id(RECOVERY_MESSAGE_ID, lang, format)
     send_message.delay(message_id, email, user_data['token'], format)

--- a/settings.py
+++ b/settings.py
@@ -242,6 +242,8 @@ LOGGING = {
 PROD_DETAILS_CACHE_NAME = 'product_details'
 PROD_DETAILS_CACHE_TIMEOUT = None
 
+RECOVER_MSG_LANGS = config('RECOVER_MSG_LANGS', 'en', cast=Csv())
+
 if sys.argv[0].endswith('py.test') or (len(sys.argv) > 1 and sys.argv[1] == 'test'):
     # stuff that's absolutely required for a test run
     CELERY_ALWAYS_EAGER = True


### PR DESCRIPTION
If user language is not supported send english. Also clean up the task a
bit.