### PR TITLE
Add ability to deploy demo instances from github

### DIFF
--- a/.demo_env
+++ b/.demo_env
@@ -1,0 +1,4 @@
+DEBUG=False
+DATABASE_URL=sqlite:///basket.db
+CELERY_ALWAYS_EAGER=True
+SECRET_KEY=sssssssssshhhhhhhhhhh

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 echo "Logging into the Docker Hub"
 docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
@@ -13,18 +13,41 @@ docker push ${DOCKER_REPOSITORY}:last_successful_build
 echo "Installing Deis client"
 curl -sSL http://deis.io/deis-cli/install.sh | sh
 
-DEIS_REGIONS=( us-west eu-west )
-if [[ "$1" == "prod" ]]; then
-  DEIS_APPS=( $DEIS_PROD_APP $DEIS_ADMIN_APP )
-else
-  DEIS_APPS=( $DEIS_DEV_APP $DEIS_STAGE_APP $DEIS_ADMIN_STAGE_APP )
-fi
+DEIS_REGIONS=( us-west )
+
+case "$1" in
+  "demo")
+    DEIS_APP_NAME="basket-demo-${CIRCLE_BRANCH#demo__}"
+    # convert underscores to dashes. Deis does _not_ like underscores.
+    DEIS_APP_NAME=$( echo "$DEIS_APP_NAME" | tr "_" "-" )
+    DEIS_APPS=( $DEIS_APP_NAME )
+    ;;
+  "stage")
+    DEIS_APPS=( $DEIS_DEV_APP $DEIS_STAGE_APP $DEIS_ADMIN_STAGE_APP )
+    DEIS_REGIONS+=( eu-west )
+    ;;
+  "prod")
+    DEIS_APPS=( $DEIS_PROD_APP $DEIS_ADMIN_APP )
+    DEIS_REGIONS+=( eu-west )
+    ;;
+esac
 
 for region in "${DEIS_REGIONS[@]}"; do
   DEIS_CONTROLLER="https://deis.${region}.moz.works"
   echo "Logging into the Deis Controller at $DEIS_CONTROLLER"
   ./deis login "$DEIS_CONTROLLER" --username "$DEIS_USERNAME" --password "$DEIS_PASSWORD"
   for appname in "${DEIS_APPS[@]}"; do
+    # attempt to create the app for demo deploys
+    if [[ "$1" == "demo" ]]; then
+      echo "Creating the demo app $appname"
+      if ./deis apps:create "$appname" --no-remote; then
+        echo "Giving github user $CIRCLE_USERNAME perms for the app"
+        ./deis perms:create "$CIRCLE_USERNAME" -a "$appname" || true
+        echo "Configuring the new demo app"
+        ./deis config:push -a "$appname" -p .demo_env
+      fi
+    fi
+
     # skip admin apps in eu-west
     if [[ "$region" == "eu-west" && "$appname" == *admin* ]]; then
       continue
@@ -33,13 +56,15 @@ for region in "${DEIS_REGIONS[@]}"; do
     echo "Pulling $DOCKER_IMAGE_TAG into Deis app $appname in $region"
     ./deis pull "$DOCKER_IMAGE_TAG" -a "$appname"
 
-    echo "Pinging New Relic about the deployment of $NR_APP"
-    nr_desc="CircleCI built $DOCKER_IMAGE_TAG and deployed it to Deis in $region"
-    curl -H "x-api-key:$NEWRELIC_API_KEY" \
-         -d "deployment[app_name]=$NR_APP" \
-         -d "deployment[revision]=$CIRCLE_SHA1" \
-         -d "deployment[user]=CircleCI" \
-         -d "deployment[description]=$nr_desc" \
-         https://api.newrelic.com/deployments.xml
+    if [[ "$1" != "demo" ]]; then
+      echo "Pinging New Relic about the deployment of $NR_APP"
+      nr_desc="CircleCI built $DOCKER_IMAGE_TAG and deployed it to Deis in $region"
+      curl -H "x-api-key:$NEWRELIC_API_KEY" \
+           -d "deployment[app_name]=$NR_APP" \
+           -d "deployment[revision]=$CIRCLE_SHA1" \
+           -d "deployment[user]=CircleCI" \
+           -d "deployment[description]=$nr_desc" \
+           https://api.newrelic.com/deployments.xml
+    fi
   done
 done

--- a/circle.yml
+++ b/circle.yml
@@ -46,6 +46,11 @@ test:
     - docker run --env-file .env --link db -v "$CIRCLE_TEST_REPORTS/django:/app/test-results" "$DOCKER_IMAGE_TAG" bin/run-tests.sh
 
 deployment:
+  demo:
+    branch: /demo__.+/
+    owner: mozilla
+    commands:
+      - bin/deploy.sh demo
   stage:
     branch: master
     owner: mozilla

--- a/settings.py
+++ b/settings.py
@@ -4,6 +4,7 @@ import socket
 import struct
 import sys
 from datetime import timedelta
+from uuid import uuid4
 
 import dj_database_url
 import django_cache_url
@@ -179,7 +180,7 @@ EXACTTARGET_USER = config('EXACTTARGET_USER', None)
 EXACTTARGET_PASS = config('EXACTTARGET_PASS', None)
 EXACTTARGET_DATA = config('EXACTTARGET_DATA', None)
 EXACTTARGET_OPTIN_STAGE = config('EXACTTARGET_OPTIN_STAGE', None)
-SUPERTOKEN = config('SUPERTOKEN')
+SUPERTOKEN = config('SUPERTOKEN', str(uuid4()))
 ET_CLIENT_ID = config('ET_CLIENT_ID', None)
 ET_CLIENT_SECRET = config('ET_CLIENT_SECRET', None)
 


### PR DESCRIPTION
Similar to how bedrock works, if you push to a branch named e.g. "demo__my-feature" a new demo basket app will be created for you and deployed to at `basket-demo-my-feature.us-west.moz.works`.