### PR TITLE
Add maintenance mode to queue tasks while SF is down

### DIFF
--- a/news/management/commands/process_maintenance_queue.py
+++ b/news/management/commands/process_maintenance_queue.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+
+from news.models import QueuedTask
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-n', '--num-tasks',
+            type=int,
+            default=settings.QUEUE_BATCH_SIZE,
+            help='Number of tasks to process ({})'.format(settings.QUEUE_BATCH_SIZE))
+
+    def handle(self, *args, **options):
+        if settings.MAINTENANCE_MODE:
+            raise CommandError('Command unavailable in maintenance mode')
+
+        count = 0
+        for task in QueuedTask.objects.all()[:settings.QUEUE_BATCH_SIZE]:
+            task.retry()
+            count += 1
+
+        print '{} processed. {} remaining.'.format(count, QueuedTask.objects.count())

--- a/news/migrations/0004_queuedtask.py
+++ b/news/migrations/0004_queuedtask.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('news', '0003_auto_20151202_0808'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='QueuedTask',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('when', models.DateTimeField(default=django.utils.timezone.now, editable=False)),
+                ('name', models.CharField(max_length=255)),
+                ('args', jsonfield.fields.JSONField(default=[])),
+                ('kwargs', jsonfield.fields.JSONField(default={})),
+            ],
+            options={
+                'ordering': ['pk'],
+            },
+        ),
+    ]

--- a/settings.py
+++ b/settings.py
@@ -290,6 +290,9 @@ RECOVER_MSG_LANGS = config('RECOVER_MSG_LANGS', 'en', cast=Csv())
 
 SYNC_KEY = config('SYNC_KEY', None)
 
+MAINTENANCE_MODE = config('MAINTENANCE_MODE', False, cast=bool)
+QUEUE_BATCH_SIZE = config('QUEUE_BATCH_SIZE', 500, cast=int)
+
 if sys.argv[0].endswith('py.test') or (len(sys.argv) > 1 and sys.argv[1] == 'test'):
     # stuff that's absolutely required for a test run
     CELERY_ALWAYS_EAGER = True


### PR DESCRIPTION
1. Add a setting that will enable maintenance mode.
2. Exempt some tasks from maintenance mode.
3. Add a command to resend said queued tasks.