### PR TITLE
Flip SFDC test data switch for testing email domains

### DIFF
--- a/news/backends/sfdc.py
+++ b/news/backends/sfdc.py
@@ -94,6 +94,10 @@ def to_vendor(data):
         # True for every contact moving through basket
         'Subscriber__c': True,
     }
+    if 'email' in data:
+        for domain in settings.TESTING_EMAIL_DOMAINS:
+            if data['email'].endswith(u'@{}'.format(domain)):
+                contact['UAT_Test_Data__c'] = True
 
     if 'country' in data:
         data['country'] = data['country'].lower()

--- a/settings.py
+++ b/settings.py
@@ -291,6 +291,7 @@ PROD_DETAILS_CACHE_TIMEOUT = None
 RECOVER_MSG_LANGS = config('RECOVER_MSG_LANGS', 'en', cast=Csv())
 
 SYNC_KEY = config('SYNC_KEY', None)
+TESTING_EMAIL_DOMAINS = config('TESTING_EMAIL_DOMAINS', 'restmail.net,example.com', cast=Csv())
 
 MAINTENANCE_MODE = config('MAINTENANCE_MODE', False, cast=bool)
 QUEUE_BATCH_SIZE = config('QUEUE_BATCH_SIZE', 500, cast=int)
@@ -304,6 +305,7 @@ if sys.argv[0].endswith('py.test') or (len(sys.argv) > 1 and sys.argv[1] == 'tes
     SFDC_SETTINGS.pop('password', None)
     SFMC_SETTINGS.pop('clientid', None)
     SFMC_SETTINGS.pop('clientsecret', None)
+    TESTING_EMAIL_DOMAINS = []
 
 SAML_ENABLE = config('SAML_ENABLE', default=False, cast=bool)
 if SAML_ENABLE:


### PR DESCRIPTION
There is a flag on our SFDC records that indicates that it was added as a User Acceptance Test. We can always flip this flag for known testing email address domains. By default this will be restmail.net (mozilla's own email testing service) and example.com which won't actually do anything within SFDC or SFMC regardless.